### PR TITLE
[FIX] enums & entity 수정

### DIFF
--- a/src/main/java/umc/haruchi/HaruchiApplication.java
+++ b/src/main/java/umc/haruchi/HaruchiApplication.java
@@ -2,10 +2,12 @@ package umc.haruchi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
 @EnableJpaRepositories
+@EnableJpaAuditing
 public class HaruchiApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/umc/haruchi/domain/DayBudget.java
+++ b/src/main/java/umc/haruchi/domain/DayBudget.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.ser.Serializers;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 import umc.haruchi.domain.common.BaseEntity;
 import umc.haruchi.domain.enums.DayBudgetStatus;
 import umc.haruchi.domain.mapping.BudgetRedistribution;
@@ -15,6 +17,8 @@ import java.util.List;
 @Entity
 @Getter
 @Builder
+@DynamicUpdate
+@DynamicInsert
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class DayBudget extends BaseEntity {

--- a/src/main/java/umc/haruchi/domain/DayBudget.java
+++ b/src/main/java/umc/haruchi/domain/DayBudget.java
@@ -8,6 +8,7 @@ import umc.haruchi.domain.common.BaseEntity;
 import umc.haruchi.domain.enums.DayBudgetStatus;
 import umc.haruchi.domain.mapping.BudgetRedistribution;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -47,4 +48,10 @@ public class DayBudget extends BaseEntity {
 
     @OneToMany(mappedBy = "dayBudget", cascade = CascadeType.ALL)
     private List<Expenditure> expenditureList = new ArrayList<>();
+
+    @PrePersist
+    public void prePersist() {
+        LocalDate now = LocalDate.now();
+        this.day = now.getDayOfMonth();
+    }
 }

--- a/src/main/java/umc/haruchi/domain/DayBudget.java
+++ b/src/main/java/umc/haruchi/domain/DayBudget.java
@@ -48,9 +48,11 @@ public class DayBudget extends BaseEntity {
     private MonthBudget monthBudget;
 
     @OneToMany(mappedBy = "dayBudget", cascade = CascadeType.ALL)
+    @Builder.Default
     private List<Income> incomeList = new ArrayList<>();
 
     @OneToMany(mappedBy = "dayBudget", cascade = CascadeType.ALL)
+    @Builder.Default
     private List<Expenditure> expenditureList = new ArrayList<>();
 
     @PrePersist

--- a/src/main/java/umc/haruchi/domain/Expenditure.java
+++ b/src/main/java/umc/haruchi/domain/Expenditure.java
@@ -18,7 +18,7 @@ public class Expenditure extends BaseEntity {
     @Column(nullable = false, columnDefinition = "bigint default 0")
     private Long expenditureAmount;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "bigint default 0")
     private Long expenditureCategory;
 
     @Column(nullable = true, length = 10)

--- a/src/main/java/umc/haruchi/domain/Expenditure.java
+++ b/src/main/java/umc/haruchi/domain/Expenditure.java
@@ -2,11 +2,15 @@ package umc.haruchi.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 import umc.haruchi.domain.common.BaseEntity;
 
 @Entity
 @Getter
 @Builder
+@DynamicUpdate
+@DynamicInsert
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Expenditure extends BaseEntity {

--- a/src/main/java/umc/haruchi/domain/Expenditure.java
+++ b/src/main/java/umc/haruchi/domain/Expenditure.java
@@ -5,6 +5,7 @@ import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 import umc.haruchi.domain.common.BaseEntity;
+import umc.haruchi.domain.enums.ExpenditureCategory;
 
 @Entity
 @Getter
@@ -22,8 +23,9 @@ public class Expenditure extends BaseEntity {
     @Column(nullable = false, columnDefinition = "bigint default 0")
     private Long expenditureAmount;
 
-    @Column(nullable = false, columnDefinition = "bigint default 0")
-    private Long expenditureCategory;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, columnDefinition = "VARCHAR(15) DEFAULT 'NONE'")
+    private ExpenditureCategory expenditureCategory;
 
     @Column(nullable = true, length = 10)
     private String memo;

--- a/src/main/java/umc/haruchi/domain/Income.java
+++ b/src/main/java/umc/haruchi/domain/Income.java
@@ -5,6 +5,7 @@ import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 import umc.haruchi.domain.common.BaseEntity;
+import umc.haruchi.domain.enums.IncomeCategory;
 
 @Entity
 @Getter
@@ -22,8 +23,9 @@ public class Income extends BaseEntity {
     @Column(nullable = false, columnDefinition = "bigint default 0")
     private Long incomeAmount;
 
-    @Column(nullable = false, columnDefinition = "bigint default 0")
-    private Long incomeCategory;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, columnDefinition = "VARCHAR(15) DEFAULT 'NONE'")
+    private IncomeCategory incomeCategory;
 
     @Column(nullable = true, length = 10)
     private String memo;

--- a/src/main/java/umc/haruchi/domain/Income.java
+++ b/src/main/java/umc/haruchi/domain/Income.java
@@ -18,7 +18,7 @@ public class Income extends BaseEntity {
     @Column(nullable = false, columnDefinition = "bigint default 0")
     private Long incomeAmount;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "bigint default 0")
     private Long incomeCategory;
 
     @Column(nullable = true, length = 10)

--- a/src/main/java/umc/haruchi/domain/Income.java
+++ b/src/main/java/umc/haruchi/domain/Income.java
@@ -2,11 +2,15 @@ package umc.haruchi.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 import umc.haruchi.domain.common.BaseEntity;
 
 @Entity
 @Getter
 @Builder
+@DynamicUpdate
+@DynamicInsert
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Income extends BaseEntity {

--- a/src/main/java/umc/haruchi/domain/Member.java
+++ b/src/main/java/umc/haruchi/domain/Member.java
@@ -2,6 +2,8 @@ package umc.haruchi.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 import umc.haruchi.domain.common.BaseEntity;
 import umc.haruchi.domain.enums.MemberStatus;
 
@@ -12,6 +14,8 @@ import java.util.List;
 @Entity
 @Getter
 @Builder
+@DynamicUpdate
+@DynamicInsert
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity {

--- a/src/main/java/umc/haruchi/domain/Member.java
+++ b/src/main/java/umc/haruchi/domain/Member.java
@@ -3,7 +3,7 @@ package umc.haruchi.domain;
 import jakarta.persistence.*;
 import lombok.*;
 import umc.haruchi.domain.common.BaseEntity;
-import umc.haruchi.domain.enums.LoginStatus;
+import umc.haruchi.domain.enums.MemberStatus;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -33,8 +33,8 @@ public class Member extends BaseEntity {
     private String password;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, columnDefinition = "VARCHAR(10) DEFAULT 'F'")
-    private LoginStatus loginStatus;
+    @Column(nullable = false, columnDefinition = "VARCHAR(10) DEFAULT 'LOGIN'")
+    private MemberStatus memberStatus;
 
     @Column(nullable = true)
     private LocalDate inactiveDate;

--- a/src/main/java/umc/haruchi/domain/Member.java
+++ b/src/main/java/umc/haruchi/domain/Member.java
@@ -53,5 +53,6 @@ public class Member extends BaseEntity {
     private MemberToken memberToken;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    @Builder.Default
     private List<MonthBudget> monthBudgetList = new ArrayList<>();
 }

--- a/src/main/java/umc/haruchi/domain/MemberToken.java
+++ b/src/main/java/umc/haruchi/domain/MemberToken.java
@@ -2,11 +2,15 @@ package umc.haruchi.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 import umc.haruchi.domain.common.BaseEntity;
 
 @Entity
 @Getter
 @Builder
+@DynamicUpdate
+@DynamicInsert
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberToken extends BaseEntity {

--- a/src/main/java/umc/haruchi/domain/MonthBudget.java
+++ b/src/main/java/umc/haruchi/domain/MonthBudget.java
@@ -40,6 +40,7 @@ public class MonthBudget extends BaseEntity {
     private Member member;
 
     @OneToMany(mappedBy = "monthBudget", cascade = CascadeType.ALL)
+    @Builder.Default
     private List<DayBudget> dayBudgetList = new ArrayList<>();
 
     @PrePersist

--- a/src/main/java/umc/haruchi/domain/MonthBudget.java
+++ b/src/main/java/umc/haruchi/domain/MonthBudget.java
@@ -2,6 +2,8 @@ package umc.haruchi.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 import umc.haruchi.domain.common.BaseEntity;
 
 import java.time.LocalDate;
@@ -11,6 +13,8 @@ import java.util.List;
 @Entity
 @Getter
 @Builder
+@DynamicUpdate
+@DynamicInsert
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MonthBudget extends BaseEntity {

--- a/src/main/java/umc/haruchi/domain/PullMinusClosing.java
+++ b/src/main/java/umc/haruchi/domain/PullMinusClosing.java
@@ -3,6 +3,8 @@ package umc.haruchi.domain;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 import umc.haruchi.domain.common.BaseEntity;
 import umc.haruchi.domain.enums.RedistributionOption;
 import umc.haruchi.domain.mapping.BudgetRedistribution;
@@ -12,6 +14,8 @@ import java.time.LocalDate;
 @Entity
 @Getter
 @Builder
+@DynamicUpdate
+@DynamicInsert
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class PullMinusClosing extends BaseEntity {

--- a/src/main/java/umc/haruchi/domain/PushPlusClosing.java
+++ b/src/main/java/umc/haruchi/domain/PushPlusClosing.java
@@ -3,6 +3,8 @@ package umc.haruchi.domain;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 import umc.haruchi.domain.common.BaseEntity;
 import umc.haruchi.domain.enums.RedistributionOption;
 import umc.haruchi.domain.mapping.BudgetRedistribution;
@@ -12,6 +14,8 @@ import java.time.LocalDate;
 @Entity
 @Getter
 @Builder
+@DynamicUpdate
+@DynamicInsert
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class PushPlusClosing extends BaseEntity {

--- a/src/main/java/umc/haruchi/domain/enums/ExpenditureCategory.java
+++ b/src/main/java/umc/haruchi/domain/enums/ExpenditureCategory.java
@@ -1,0 +1,37 @@
+package umc.haruchi.domain.enums;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public enum ExpenditureCategory {
+    NONE("미분류"),
+    FOOD("식비"),
+    CAFE("카페"),
+    TRANSPORT("교통"),
+    HOBBY("취미"),
+    FASHION("패션"),
+    EDUCATION("교육"),
+    EVENT("경조사"),
+    SUBSCRIPTION("구독"),
+    OTHER("기타")
+    ;
+
+    private String krName;
+
+    ExpenditureCategory(String krName) {
+        this.krName = krName;
+    }
+
+    public String getKrName() {
+        return krName;
+    }
+
+    public static ExpenditureCategory nameOf(String krName) {
+        for (ExpenditureCategory category : ExpenditureCategory.values()) {
+            if (category.getKrName().equals(krName)) {
+                return category;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/umc/haruchi/domain/enums/IncomeCategory.java
+++ b/src/main/java/umc/haruchi/domain/enums/IncomeCategory.java
@@ -1,0 +1,33 @@
+package umc.haruchi.domain.enums;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public enum IncomeCategory {
+    NONE("미분류"),
+    ALLOWANCE("용돈"),
+    SALARY("월급"),
+    SIDELINE("부수입"),
+    BONUS("상여"),
+    INTEREST("금융소득"),
+    OTHER("기타");
+
+    private String krName;
+
+    IncomeCategory(String krName) {
+        this.krName = krName;
+    }
+
+    public String getKrName() {
+        return krName;
+    }
+
+    public static IncomeCategory nameOf(String krName) {
+        for (IncomeCategory category : IncomeCategory.values()) {
+            if (category.getKrName().equals(krName)) {
+                return category;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/umc/haruchi/domain/enums/LoginStatus.java
+++ b/src/main/java/umc/haruchi/domain/enums/LoginStatus.java
@@ -1,5 +1,0 @@
-package umc.haruchi.domain.enums;
-
-public enum LoginStatus {
-    LOGIN, LOGOUT
-}

--- a/src/main/java/umc/haruchi/domain/enums/MemberStatus.java
+++ b/src/main/java/umc/haruchi/domain/enums/MemberStatus.java
@@ -1,0 +1,5 @@
+package umc.haruchi.domain.enums;
+
+public enum MemberStatus {
+    LOGIN, LOGOUT, INACTIVE, DELETED
+}

--- a/src/main/java/umc/haruchi/domain/mapping/BudgetRedistribution.java
+++ b/src/main/java/umc/haruchi/domain/mapping/BudgetRedistribution.java
@@ -3,6 +3,8 @@ package umc.haruchi.domain.mapping;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 import umc.haruchi.domain.DayBudget;
 import umc.haruchi.domain.PullMinusClosing;
 import umc.haruchi.domain.PushPlusClosing;
@@ -14,6 +16,8 @@ import java.util.List;
 @Entity
 @Getter
 @Builder
+@DynamicUpdate
+@DynamicInsert
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class BudgetRedistribution extends BaseEntity {

--- a/src/main/java/umc/haruchi/repository/TempRepository.java
+++ b/src/main/java/umc/haruchi/repository/TempRepository.java
@@ -1,0 +1,4 @@
+package umc.haruchi.repository;
+
+public class TempRepository {
+}

--- a/src/main/java/umc/haruchi/service/TempService.java
+++ b/src/main/java/umc/haruchi/service/TempService.java
@@ -1,0 +1,4 @@
+package umc.haruchi.service;
+
+public class TempService {
+}


### PR DESCRIPTION
## 💡 관련 이슈

#2 

## 📢 작업 내용

- Enum LoginStatus를 MemberStatus로 변경 및 내부 코드 추가 (INACTIVE, DELETED)
  - Member 엔티티의 LoginStatus를 MemberStatus로 변경 (기본값 LOGIN)
- ~Income, Expenditure 엔티티의 Category 필드의 기본값을 0으로 설정~
- DayBudget 엔티티에 day 필드를 현재 일로 설정해주는 메서드 추가
- 모든 엔티티에 @DynamicInsert와 @DynamicUpdate 어노테이션 추가
  - HaruchiApplication.java 앱에 @EnableJpaAuditing 어노테이션 추가
- Enum IncomeCategory와 ExpenditureCategory 추가
  - Income, Expenditure 엔티티의 Category 필드 타입을 Long에서 위에 추가한 Enum으로 변경 (기본값 NONE)
- 연관관계가 일대다인 테이블들 중 @OneToMany 어노테이션을 가진 필드에 @Builder.Default 추가

## 🗨️ 리뷰 요구사항(선택)



## ✅ 체크리스트

- [x]  코드가 정상적으로 컴파일되나요?
- [x]  이슈 내용을 전부 구현했나요?
- [x]  작업 기간 내에 개발을 완료했나요?
- [x]  리뷰어를 선택했나요?
- [x]  라벨을 지정했나요?
