### PR TITLE
[FEAT] 이메일 인증 방식 회원가입 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,19 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
+	testAnnotationProcessor('org.projectlombok:lombok')
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	// spring mail
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	// spring security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/umc/haruchi/HaruchiApplication.java
+++ b/src/main/java/umc/haruchi/HaruchiApplication.java
@@ -2,10 +2,11 @@ package umc.haruchi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 @EnableJpaRepositories
 @EnableJpaAuditing
 public class HaruchiApplication {

--- a/src/main/java/umc/haruchi/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/haruchi/apiPayload/code/status/ErrorStatus.java
@@ -14,7 +14,11 @@ public enum ErrorStatus implements BaseErrorCode {
     _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
     _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
-    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다.");
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+    //Member 관련 에러
+    EXISTED_NAME(HttpStatus.BAD_REQUEST, "MEMBER4001", "이미 있는 닉네임입니다."),
+    EXISTED_EMAIL(HttpStatus.BAD_REQUEST, "MEMBER4002", "이미 있는 이메일입니다.");
 
     //플젝 진행하며 추가하기..
 

--- a/src/main/java/umc/haruchi/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/haruchi/apiPayload/code/status/ErrorStatus.java
@@ -18,7 +18,10 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //Member 관련 에러
     EXISTED_NAME(HttpStatus.BAD_REQUEST, "MEMBER4001", "이미 있는 닉네임입니다."),
-    EXISTED_EMAIL(HttpStatus.BAD_REQUEST, "MEMBER4002", "이미 있는 이메일입니다.");
+    EXISTED_EMAIL(HttpStatus.BAD_REQUEST, "MEMBER4002", "이미 있는 이메일입니다."),
+    NOT_VERIFIED_EMAIL(HttpStatus.BAD_REQUEST, "MEMBER4003", "이메일이 검증되지 않았습니다."),
+    EMAIL_VERIFY_FAILED(HttpStatus.BAD_REQUEST, "MEMBER4004", "인증 번호가 일치하지 않습니다."),
+    ;
 
     //플젝 진행하며 추가하기..
 

--- a/src/main/java/umc/haruchi/apiPayload/exception/handler/MemberHandler.java
+++ b/src/main/java/umc/haruchi/apiPayload/exception/handler/MemberHandler.java
@@ -1,0 +1,11 @@
+package umc.haruchi.apiPayload.exception.handler;
+
+import umc.haruchi.apiPayload.code.BaseErrorCode;
+import umc.haruchi.apiPayload.exception.GeneralException;
+
+public class MemberHandler extends GeneralException {
+
+    public MemberHandler(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/umc/haruchi/config/EmailConfig.java
+++ b/src/main/java/umc/haruchi/config/EmailConfig.java
@@ -1,0 +1,60 @@
+package umc.haruchi.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class EmailConfig {
+
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttlsEnable;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.required}")
+    private boolean starttlsRequired;
+
+    @Value("${spring.mail.properties.mail.smtp.timeout}")
+    private int timeout;
+
+    @Bean
+    public JavaMailSender javaMailsender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+        mailSender.setDefaultEncoding("UTF-8");
+        mailSender.setJavaMailProperties(getMailProperties());
+
+        return mailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties props = new Properties();
+        props.put("mail.smtp.auth", auth);
+        props.put("mail.smtp.starttls.enable", starttlsEnable);
+        props.put("mail.smtp.starttls.required", starttlsRequired);
+        props.put("mail.smtp.timeout", timeout);
+
+        return props;
+    }
+}

--- a/src/main/java/umc/haruchi/converter/MemberConverter.java
+++ b/src/main/java/umc/haruchi/converter/MemberConverter.java
@@ -1,0 +1,29 @@
+package umc.haruchi.converter;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import umc.haruchi.domain.Member;
+import umc.haruchi.web.dto.MemberRequestDTO;
+import umc.haruchi.web.dto.MemberResponseDTO;
+
+import java.time.LocalDateTime;
+
+public class MemberConverter {
+
+    private static final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+    public static Member toMember(MemberRequestDTO.MemberJoinDTO request) {
+        return Member.builder()
+                .monthBudget(request.getMonthBudget())
+                .name(request.getName())
+                .email(request.getEmail())
+                .password(passwordEncoder.encode(request.getPassword()))
+                .build();
+    }
+
+    public static MemberResponseDTO.MemberJoinResultDTO toJoinResultDTO(Member member) {
+        return MemberResponseDTO.MemberJoinResultDTO.builder()
+                .memberId(member.getId())
+                .createdAt(LocalDateTime.now()).build();
+    }
+}

--- a/src/main/java/umc/haruchi/domain/DayBudget.java
+++ b/src/main/java/umc/haruchi/domain/DayBudget.java
@@ -48,11 +48,11 @@ public class DayBudget extends BaseEntity {
     private MonthBudget monthBudget;
 
     @OneToMany(mappedBy = "dayBudget", cascade = CascadeType.ALL)
-    @Builder.Default
+    //@Builder.Default
     private List<Income> incomeList = new ArrayList<>();
 
     @OneToMany(mappedBy = "dayBudget", cascade = CascadeType.ALL)
-    @Builder.Default
+    //@Builder.Default
     private List<Expenditure> expenditureList = new ArrayList<>();
 
     @PrePersist

--- a/src/main/java/umc/haruchi/domain/Member.java
+++ b/src/main/java/umc/haruchi/domain/Member.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import umc.haruchi.domain.common.BaseEntity;
 import umc.haruchi.domain.enums.MemberStatus;
 
@@ -33,17 +34,17 @@ public class Member extends BaseEntity {
     @Column(nullable = false, length = 20)
     private String email;
 
-    @Column(nullable = false, length = 15)
+    @Column(nullable = false, length = 65)
     private String password;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, columnDefinition = "VARCHAR(10) DEFAULT 'LOGIN'")
+    @Column(nullable = false, columnDefinition = "VARCHAR(10) DEFAULT 'LOGOUT'")
     private MemberStatus memberStatus;
 
     @Column(nullable = true)
     private LocalDate inactiveDate;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private LocalDate lastLoginDate;
 
     @Column(nullable = false, columnDefinition = "bigint default 0")
@@ -55,4 +56,8 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     @Builder.Default
     private List<MonthBudget> monthBudgetList = new ArrayList<>();
+
+    public void encodePassword(String password) {
+        this.password = password;
+    }
 }

--- a/src/main/java/umc/haruchi/domain/Member.java
+++ b/src/main/java/umc/haruchi/domain/Member.java
@@ -1,9 +1,13 @@
 package umc.haruchi.domain;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.validator.constraints.Length;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import umc.haruchi.domain.common.BaseEntity;
 import umc.haruchi.domain.enums.MemberStatus;
@@ -31,7 +35,7 @@ public class Member extends BaseEntity {
     @Column(nullable = false, length = 5)
     private String name;
 
-    @Column(nullable = false, length = 20)
+    @Column(nullable = false, length = 30)
     private String email;
 
     @Column(nullable = false, length = 65)

--- a/src/main/java/umc/haruchi/domain/common/BaseEntity.java
+++ b/src/main/java/umc/haruchi/domain/common/BaseEntity.java
@@ -1,5 +1,6 @@
 package umc.haruchi.domain.common;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
@@ -14,7 +15,9 @@ import java.time.LocalDateTime;
 @EntityListeners(AuditingEntityListener.class)
 @Getter
 public abstract class BaseEntity {
+
     @CreatedDate
+    @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     @LastModifiedDate

--- a/src/main/java/umc/haruchi/repository/MemberRepository.java
+++ b/src/main/java/umc/haruchi/repository/MemberRepository.java
@@ -1,0 +1,13 @@
+package umc.haruchi.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.haruchi.domain.Member;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByEmail(String email);
+
+    Optional<Member> findByName(String username);
+}

--- a/src/main/java/umc/haruchi/service/MemberService.java
+++ b/src/main/java/umc/haruchi/service/MemberService.java
@@ -1,0 +1,109 @@
+package umc.haruchi.service;
+
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.haruchi.converter.MemberConverter;
+import umc.haruchi.domain.Member;
+import umc.haruchi.repository.MemberRepository;
+import umc.haruchi.web.dto.MemberRequestDTO;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Optional;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder encoder = new BCryptPasswordEncoder();
+    private final JavaMailSender mailSender;
+    private final StringRedisTemplate stringRedisTemplate;
+    private final RedisTemplate redisTemplate;
+
+    public static int code;
+
+    @Transactional
+    public Member joinMember(MemberRequestDTO.MemberJoinDTO request) throws Exception {
+
+        if (memberRepository.findByName(request.getName()).isPresent()) {
+            throw new Exception("이미 존재하는 닉네임입니다.");
+        }
+
+//        if (memberRepository.findByEmail(request.getEmail()).isPresent()) {
+//            throw new Exception("이미 존재하는 이메일입니다.");
+//        }
+
+        Member newMember = MemberConverter.toMember(request);
+        newMember.encodePassword(encoder.encode(newMember.getPassword()));
+        return memberRepository.save(newMember);
+    }
+
+    @Transactional
+    public void checkDuplicatedEmail(String email) throws Exception {
+        Optional<Member> member = memberRepository.findByEmail(email);
+        if (member.isPresent()) {
+            throw new Exception("이미 가입된 이메일입니다.");
+        }
+    }
+
+    @Transactional
+    public MimeMessage createMessage(String to) throws Exception {
+
+        checkDuplicatedEmail(to);
+        MimeMessage message = mailSender.createMimeMessage();
+        code = (int)(Math.random() * 90000) + 100000;
+
+        message.setFrom(new InternetAddress("haruchi@haruchi.com", "Haruchi_Admin"));
+        message.addRecipients(Message.RecipientType.TO, to);
+        message.setSubject("Haruchi 회원가입 이메일 인증");
+
+        String msg = "";
+        msg += "<h3>" + "Haruchi 이메일 인증 번호입니다." + "</h3>";
+        msg += "<h1>" + code + "</h1>";
+        msg += "<h3>" + "감사합니다." + "</h3>";
+        message.setText(msg, "utf-8", "html");
+
+        return message;
+    }
+
+    @Transactional
+    public void sendSimpleMessage(String to) throws Exception {
+
+        MimeMessage message = createMessage(to);
+        try {
+            mailSender.send(message);
+            saveVerificationCode(to, String.valueOf(code));
+        } catch (MailException es) {
+            es.printStackTrace();
+            throw new IllegalArgumentException();
+        }
+    }
+
+    public void saveVerificationCode(String email, String code) {
+        redisTemplate.opsForValue().set(email, code, 3, TimeUnit.MINUTES);
+    }
+
+    public String getVerificationCode(String email) {
+        return (String) redisTemplate.opsForValue().get(email);
+    }
+
+    public void verificationEmail(String code, String savedCode) throws Exception {
+        if (!code.equals(savedCode)) {
+            throw new Exception("인증 번호가 일치하지 않습니다.");
+        }
+    }
+}

--- a/src/main/java/umc/haruchi/service/MemberService.java
+++ b/src/main/java/umc/haruchi/service/MemberService.java
@@ -41,13 +41,18 @@ public class MemberService {
     @Transactional
     public Member joinMember(MemberRequestDTO.MemberJoinDTO request) throws Exception {
 
+        if (!request.isVerifiedEmail()) {
+            throw new MemberHandler(ErrorStatus.NOT_VERIFIED_EMAIL);
+        }
+
         if (memberRepository.findByName(request.getName()).isPresent()) {
             throw new MemberHandler(ErrorStatus.EXISTED_NAME);
         }
 
-//        if (memberRepository.findByEmail(request.getEmail()).isPresent()) {
-//            throw new Exception("이미 존재하는 이메일입니다.");
-//        }
+        // 이메일 인증 요청에서 미리 처리하니까 삭제해도 됨
+        if (memberRepository.findByEmail(request.getEmail()).isPresent()) {
+            throw new Exception("이미 존재하는 이메일입니다.");
+        }
 
         Member newMember = MemberConverter.toMember(request);
         newMember.encodePassword(encoder.encode(newMember.getPassword()));
@@ -105,7 +110,7 @@ public class MemberService {
 
     public void verificationEmail(String code, String savedCode) throws Exception {
         if (!code.equals(savedCode)) {
-            throw new Exception("인증 번호가 일치하지 않습니다.");
+            throw new MemberHandler(ErrorStatus.EXISTED_EMAIL);
         }
     }
 }

--- a/src/main/java/umc/haruchi/service/MemberService.java
+++ b/src/main/java/umc/haruchi/service/MemberService.java
@@ -13,6 +13,8 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.haruchi.apiPayload.code.status.ErrorStatus;
+import umc.haruchi.apiPayload.exception.handler.MemberHandler;
 import umc.haruchi.converter.MemberConverter;
 import umc.haruchi.domain.Member;
 import umc.haruchi.repository.MemberRepository;
@@ -40,7 +42,7 @@ public class MemberService {
     public Member joinMember(MemberRequestDTO.MemberJoinDTO request) throws Exception {
 
         if (memberRepository.findByName(request.getName()).isPresent()) {
-            throw new Exception("이미 존재하는 닉네임입니다.");
+            throw new MemberHandler(ErrorStatus.EXISTED_NAME);
         }
 
 //        if (memberRepository.findByEmail(request.getEmail()).isPresent()) {
@@ -56,7 +58,7 @@ public class MemberService {
     public void checkDuplicatedEmail(String email) throws Exception {
         Optional<Member> member = memberRepository.findByEmail(email);
         if (member.isPresent()) {
-            throw new Exception("이미 가입된 이메일입니다.");
+            throw new MemberHandler(ErrorStatus.EXISTED_EMAIL);
         }
     }
 

--- a/src/main/java/umc/haruchi/web/controller/MemberApiController.java
+++ b/src/main/java/umc/haruchi/web/controller/MemberApiController.java
@@ -1,0 +1,74 @@
+package umc.haruchi.web.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import jakarta.mail.MessagingException;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import umc.haruchi.apiPayload.ApiResponse;
+import umc.haruchi.apiPayload.code.status.SuccessStatus;
+import umc.haruchi.converter.MemberConverter;
+import umc.haruchi.domain.Member;
+import umc.haruchi.service.MemberService;
+import umc.haruchi.web.dto.MemberRequestDTO;
+import umc.haruchi.web.dto.MemberResponseDTO;
+
+import java.io.UnsupportedEncodingException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class MemberApiController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/signup")
+    @Operation(summary = "회원가입 API", description = "이메일 인증으로 회원가입을 진행하는 API")
+    public ApiResponse<MemberResponseDTO.MemberJoinResultDTO> join(@Valid @RequestBody MemberRequestDTO.MemberJoinDTO request) throws Exception {
+        Member member = memberService.joinMember(request);
+        return ApiResponse.onSuccess(MemberConverter.toJoinResultDTO(member));
+    }
+
+    @PostMapping("/signup/email")
+    @Operation(summary = "이메일 인증 요청 API", description = "이메일에 인증 번호를 보내는 API")
+    @Parameters({
+            @Parameter(name = "email", description = "인증을 받을 메일 주소")
+    })
+    public ApiResponse<MemberResponseDTO> sendEmail(@Valid @RequestParam("email") String email) throws Exception {
+        memberService.sendSimpleMessage(email);
+        return ApiResponse.onSuccess(null);
+    }
+
+    @PostMapping("/signup/email/verify")
+    @Operation(summary = "이메일 인증 확인 API", description = "이메일 인증 번호를 확인하는 API")
+    @Parameters({
+            @Parameter(name = "email", description = "인증을 받을 메일 주소"),
+            @Parameter(name = "code", description = "받은 인증 코드")
+    })
+    public ApiResponse<MemberResponseDTO> verifyEmail(@Valid @RequestParam("email") String email,
+                                                      @RequestParam("code") String code) throws Exception {
+        String authCode = memberService.getVerificationCode(email);
+        memberService.verificationEmail(code, authCode);
+        return ApiResponse.onSuccess(null);
+    }
+
+    @PostMapping("/login")
+    @Operation(summary = "로그인 API", description = "로그인을 진행하는 API")
+    public ApiResponse<MemberResponseDTO.MemberJoinResultDTO> login(@Valid @RequestBody MemberRequestDTO member) {
+        return null;
+    }
+
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃 API", description = "로그아웃을 진행하는 API")
+    public ApiResponse<MemberResponseDTO.MemberJoinResultDTO> logout(@Valid @RequestBody MemberRequestDTO member) {
+        return null;
+    }
+
+    @PostMapping("/delete")
+    @Operation(summary = "회원탈퇴 API", description = "회원탈퇴를 진행하는 API")
+    public ApiResponse<MemberResponseDTO.MemberJoinResultDTO> deleteMember(@Valid @RequestBody MemberRequestDTO member) {
+        return null;
+    }
+}

--- a/src/main/java/umc/haruchi/web/controller/MemberApiController.java
+++ b/src/main/java/umc/haruchi/web/controller/MemberApiController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import jakarta.mail.MessagingException;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import umc.haruchi.apiPayload.ApiResponse;
@@ -36,7 +37,7 @@ public class MemberApiController {
     @Parameters({
             @Parameter(name = "email", description = "인증을 받을 메일 주소")
     })
-    public ApiResponse<MemberResponseDTO> sendEmail(@Valid @RequestParam("email") String email) throws Exception {
+    public ApiResponse<MemberResponseDTO> sendEmail(@Email(message = "이메일 형식이 올바르지 않습니다.") @RequestParam("email") String email) throws Exception {
         memberService.sendSimpleMessage(email);
         return ApiResponse.onSuccess(null);
     }
@@ -44,10 +45,10 @@ public class MemberApiController {
     @PostMapping("/signup/email/verify")
     @Operation(summary = "이메일 인증 확인 API", description = "이메일 인증 번호를 확인하는 API")
     @Parameters({
-            @Parameter(name = "email", description = "인증을 받을 메일 주소"),
+            @Parameter(name = "email", description = "인증을 받은 메일 주소"),
             @Parameter(name = "code", description = "받은 인증 코드")
     })
-    public ApiResponse<MemberResponseDTO> verifyEmail(@Valid @RequestParam("email") String email,
+    public ApiResponse<MemberResponseDTO> verifyEmail(@Email(message = "이메일 형식이 올바르지 않습니다.") @RequestParam("email") String email,
                                                       @RequestParam("code") String code) throws Exception {
         String authCode = memberService.getVerificationCode(email);
         memberService.verificationEmail(code, authCode);

--- a/src/main/java/umc/haruchi/web/dto/MemberRequestDTO.java
+++ b/src/main/java/umc/haruchi/web/dto/MemberRequestDTO.java
@@ -1,0 +1,50 @@
+package umc.haruchi.web.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class MemberRequestDTO {
+
+    @Getter
+    public static class MemberJoinDTO {
+
+        @NotNull
+        private Long monthBudget;
+
+        @NotBlank
+        @Size(min = 1, max = 5)
+        private String name;
+
+        @NotBlank
+        @Size(min = 10, max = 20)
+        @Email
+        private String email;
+
+        @NotBlank
+        private String password;
+    }
+
+//    @Getter
+//    public static class EmailSendDTO {
+//
+//        @NotNull
+//        @Size(min = 10, max = 20)
+//        @Email
+//        private String email;
+//    }
+//
+//    @Getter
+//    public static class EmailVerifyDTO {
+//
+//        @NotNull
+//        @Size(min = 10, max = 20)
+//        @Email
+//        private String email;
+//
+//        @NotBlank
+//        private String code;
+//    }
+}

--- a/src/main/java/umc/haruchi/web/dto/MemberRequestDTO.java
+++ b/src/main/java/umc/haruchi/web/dto/MemberRequestDTO.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
 
 public class MemberRequestDTO {
 
@@ -15,36 +16,23 @@ public class MemberRequestDTO {
         private Long monthBudget;
 
         @NotBlank
-        @Size(min = 1, max = 5)
+        @Length(min = 1, max = 5)
+        @Pattern(
+                regexp = "[a-z]",
+                message = "닉네임은 1~5자의 영문 소문자, 숫자로 이루어져야 합니다."
+        )
         private String name;
 
         @NotBlank
-        @Size(min = 10, max = 20)
-        @Email
+        @Length(min = 11, max = 30)
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
         private String email;
 
         @NotBlank
+        @Length(min = 4, max = 65)
         private String password;
-    }
 
-//    @Getter
-//    public static class EmailSendDTO {
-//
-//        @NotNull
-//        @Size(min = 10, max = 20)
-//        @Email
-//        private String email;
-//    }
-//
-//    @Getter
-//    public static class EmailVerifyDTO {
-//
-//        @NotNull
-//        @Size(min = 10, max = 20)
-//        @Email
-//        private String email;
-//
-//        @NotBlank
-//        private String code;
-//    }
+        @NotNull
+        private boolean verifiedEmail;
+    }
 }

--- a/src/main/java/umc/haruchi/web/dto/MemberResponseDTO.java
+++ b/src/main/java/umc/haruchi/web/dto/MemberResponseDTO.java
@@ -1,0 +1,21 @@
+package umc.haruchi.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class MemberResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberJoinResultDTO {
+        Long memberId;
+        LocalDateTime createdAt;
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,3 +10,20 @@ spring:
       ddl-auto: update
     show-sql: true
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: haruchi@gmail.com
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail.smtp.auth: true
+      mail.smtp.timeout: 5000
+      mail.smtp.starttls.enable: true
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+  cache:
+    type: redis

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,12 +13,16 @@ spring:
   mail:
     host: smtp.gmail.com
     port: 587
-    username: haruchi@gmail.com
+    username: kej431003@gmail.com # 아래 앱 비밀번호를 생성한 이메일 입력
     password: ${MAIL_PASSWORD}
     properties:
-      mail.smtp.auth: true
-      mail.smtp.timeout: 5000
-      mail.smtp.starttls.enable: true
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          timeout: 5000
 
   data:
     redis:
@@ -26,4 +30,4 @@ spring:
       port: 6379
 
   cache:
-    type: redis
+    type: redis #redis를 설치하고 redis-cli.exe를 실행해야 함


### PR DESCRIPTION
## 💡 관련 이슈

#12 

## 📢 작업 내용

- 이메일 인증 요청 및 검증 API 구현
  - EmailConfig 추가
  - build.gradle에 mail, redis, security, jwt 관련 의존성 추가
  - application.yml에 redis와 mail, cache 관련 속성 추가 (SMTP, gmail 사용)
  - MemberApiController, MemberService 내부 메서드 구현 (JavaMailSender, RedisTemplate 사용)
  - 이메일 중복 확인, 인증 코드 검증 등 구현
- 회원가입 API 구현
  - 로그인, 로그아웃, 회원탈퇴 API 컨트롤러 임시 생성
  - MemberConverter, MemberRequestDTO, MemberResponseDTO 내부 클래스, 메서드 구현
  - Member 엔티티 필드 글자수 등 제약 조건 수정
  - MemberApiController, MemberService 내부 메서드 구현
  - email, name 등 Member 회원가입 request 제약 조건 추가 및 MemberHandler 생성
  - email 인증 여부 확인 후 회원가입 진행하도록 구현
- 회원가입 후 MemberStatus 기본값 = LOGOUT
  - 나중에 피그마 화면 나오면 바뀔 수도 있음 (회원가입 후 즉시 로그인 등)
- BaseEntity의 createdAt nullable과 updatable false로 설정

## 🗨️ 리뷰 요구사항(선택)

- 브랜치 이름 feat/2-api#1보다 괜찮은 거 뭐가 있을까요? 🤔 

- 회원가입 requestDTO(monthBudget, name, email, password, verifiedEmail)에서
  - monthBudget(한달예산) 받은 거로 MonthBudget 엔티티의 monthBudget 필드에 채우기
    - monthBudget(한달예산)을 남은 일수로 나눴을 때의 금액(하루예산)에서,
      - 십의자리 이하는 절사해서 Member 엔티티의 safeBox 필드에 채우기 
      - 절사한 금액을 DayBudget 엔티티의 dayBudget 필드에 각각 채우기
  - 이런 과정을 거쳐야 하는데, 이건 루베님이 맡은 '한달 예산 수정 API'에서 구현해야 할 것 같아서 스킵했습니다. 😥

## ✅ 체크리스트

- [x]  코드가 정상적으로 컴파일되나요?
- [ ]  이슈 내용을 전부 구현했나요?
- [ ]  작업 기간 내에 개발을 완료했나요?
- [x]  리뷰어를 선택했나요?
- [x]  라벨을 지정했나요?
