### PR TITLE
[FEAT] 지출 영수증 관련 조회 API 구현 

### DIFF
--- a/src/main/java/umc/haruchi/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/haruchi/apiPayload/code/status/ErrorStatus.java
@@ -46,6 +46,7 @@ public enum ErrorStatus implements BaseErrorCode {
     OVER_OF_REMAINING_MONTH_BUDGET(HttpStatus.BAD_REQUEST, "REDISTRIBUTION4008", "당기는 금액이 남은 한달 예산을 초과합니다."),
     FINAL_DAY(HttpStatus.BAD_REQUEST, "REDISTRIBUTION4009", "마지막 날에는 해당 기능을 사용할 수 없습니다."),
     ZERO_AMOUNT(HttpStatus.BAD_REQUEST, "REDISTRIBUTION4010", "amount가 0일 때는 1/n을 할 수 없습니다."),
+    NOTHING_CLOSING(HttpStatus.BAD_REQUEST, "REDISTRIBUTION4011", "지출 마감을 아직 한번도 하지 않았습니다."),
 
     // Income 관련 에러
     INCOME_NOT_EXIST(HttpStatus.NOT_FOUND, "INCOME4001", "해당 수입이 존재하지 않습니다."),

--- a/src/main/java/umc/haruchi/converter/BudgetRedistributionConverter.java
+++ b/src/main/java/umc/haruchi/converter/BudgetRedistributionConverter.java
@@ -35,7 +35,6 @@ public class BudgetRedistributionConverter {
         return PushPlusClosing.builder()
                 .closingOption(true)
                 .redistributionOption(requestDTO.getRedistributionOption())
-                .amount(requestDTO.getAmount())
                 .sourceDayBudget(dayBudget)
                 .targetDayBudget(null)
                 .build();
@@ -45,7 +44,6 @@ public class BudgetRedistributionConverter {
         return PullMinusClosing.builder()
                 .closingOption(true)
                 .redistributionOption(requestDTO.getRedistributionOption())
-                .amount(requestDTO.getAmount())
                 .sourceDayBudget(null)
                 .targetDayBudget(dayBudget)
                 .build();

--- a/src/main/java/umc/haruchi/converter/BudgetRedistributionConverter.java
+++ b/src/main/java/umc/haruchi/converter/BudgetRedistributionConverter.java
@@ -1,12 +1,13 @@
 package umc.haruchi.converter;
 
-import umc.haruchi.domain.DayBudget;
-import umc.haruchi.domain.PullMinusClosing;
-import umc.haruchi.domain.PushPlusClosing;
+import umc.haruchi.domain.*;
+import umc.haruchi.domain.enums.RedistributionOption;
 import umc.haruchi.web.dto.BudgetRedistributionRequestDTO;
 import umc.haruchi.web.dto.BudgetRedistributionResponseDTO;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 
 public class BudgetRedistributionConverter {
 
@@ -50,37 +51,122 @@ public class BudgetRedistributionConverter {
                 .build();
     }
 
-    public static BudgetRedistributionResponseDTO.budgetPushResultDTO ToBudgetPushResultDTO(PushPlusClosing pushPlusClosing) {
-        return BudgetRedistributionResponseDTO.budgetPushResultDTO.builder()
+    public static BudgetRedistributionResponseDTO.BudgetPushResultDTO toBudgetPushResultDTO(PushPlusClosing pushPlusClosing) {
+        return BudgetRedistributionResponseDTO.BudgetPushResultDTO.builder()
                 .pushId(pushPlusClosing.getId())
-                .createdAt(LocalDate.now())
+                .createdAt(LocalDateTime.now())
                 .build();
     }
 
-    public static BudgetRedistributionResponseDTO.budgetPullResultDTO ToBudgetPullResultDTO(PullMinusClosing pullMinusClosing) {
-        return BudgetRedistributionResponseDTO.budgetPullResultDTO.builder()
+    public static BudgetRedistributionResponseDTO.BudgetPullResultDTO toBudgetPullResultDTO(PullMinusClosing pullMinusClosing) {
+        return BudgetRedistributionResponseDTO.BudgetPullResultDTO.builder()
                 .pullId(pullMinusClosing.getId())
-                .createdAt(LocalDate.now())
+                .createdAt(LocalDateTime.now())
                 .build();
     }
 
-    public static BudgetRedistributionResponseDTO.budgetClosingResultDTO ToBudgetClosingResultDTO(PushPlusClosing pushPlusClosing) {
-        return BudgetRedistributionResponseDTO.budgetClosingResultDTO.builder()
+    public static BudgetRedistributionResponseDTO.BudgetClosingResultDTO toBudgetClosingResultDTO(PushPlusClosing pushPlusClosing) {
+        return BudgetRedistributionResponseDTO.BudgetClosingResultDTO.builder()
                 .closingId(pushPlusClosing.getId())
-                .createdAt(LocalDate.now())
+                .createdAt(LocalDateTime.now())
                 .build();
     }
 
-    public static BudgetRedistributionResponseDTO.budgetClosingResultDTO ToBudgetClosingResultDTO(PullMinusClosing pullMinusClosing) {
-        return BudgetRedistributionResponseDTO.budgetClosingResultDTO.builder()
+    public static BudgetRedistributionResponseDTO.BudgetClosingResultDTO toBudgetClosingResultDTO(PullMinusClosing pullMinusClosing) {
+        return BudgetRedistributionResponseDTO.BudgetClosingResultDTO.builder()
                 .closingId(pullMinusClosing.getId())
-                .createdAt(LocalDate.now())
+                .createdAt(LocalDateTime.now())
                 .build();
     }
 
-    public static BudgetRedistributionResponseDTO.getCalculatedAmountResultDTO ToGetCalculatedAmountResultDTO(Long amount) {
-        return BudgetRedistributionResponseDTO.getCalculatedAmountResultDTO.builder()
+    public static BudgetRedistributionResponseDTO.GetCalculatedAmountResultDTO toGetCalculatedAmountResultDTO(Long amount) {
+        return BudgetRedistributionResponseDTO.GetCalculatedAmountResultDTO.builder()
                 .calculatedAmount(amount)
+                .build();
+    }
+
+    public static BudgetRedistributionResponseDTO.GetIncomeDTO toGetIncomeDTO(Income income) {
+        return BudgetRedistributionResponseDTO.GetIncomeDTO.builder()
+                .incomeAmount(income.getIncomeAmount())
+                .incomeCategory(income.getIncomeCategory())
+                .incomeId(income.getId())
+                .createdAt(income.getCreatedAt())
+                .build();
+    }
+
+    public static BudgetRedistributionResponseDTO.GetExpenditureDTO toGetExpenditureDTO(Expenditure expenditure) {
+        return BudgetRedistributionResponseDTO.GetExpenditureDTO.builder()
+                .expenditureAmount(expenditure.getExpenditureAmount())
+                .expenditureCategory(expenditure.getExpenditureCategory())
+                .expenditureId(expenditure.getId())
+                .createdAt(expenditure.getCreatedAt())
+                .build();
+    }
+
+    public static BudgetRedistributionResponseDTO.GetPullDTO toGetPullDTO(PullMinusClosing pullMinusClosing) {
+        BudgetRedistributionResponseDTO.GetPullDTO.GetPullDTOBuilder builder = BudgetRedistributionResponseDTO.GetPullDTO.builder()
+                .redistributionOption(pullMinusClosing.getRedistributionOption())
+                .targetDay(pullMinusClosing.getTargetDayBudget().getDay())
+                .createdAt(pullMinusClosing.getCreatedAt())
+                .pullId(pullMinusClosing.getId());
+
+        // redistributionOption이 DATE일 때만 sourceDay를 설정
+        if (pullMinusClosing.getRedistributionOption() == RedistributionOption.DATE) {
+            builder.sourceDay(pullMinusClosing.getSourceDayBudget().getDay());
+        }
+
+        return builder.build();
+    }
+
+    public static BudgetRedistributionResponseDTO.GetPushDTO toGetPushDTO(PushPlusClosing pushPlusClosing) {
+        BudgetRedistributionResponseDTO.GetPushDTO.GetPushDTOBuilder builder = BudgetRedistributionResponseDTO.GetPushDTO.builder()
+                .redistributionOption(pushPlusClosing.getRedistributionOption())
+                .sourceDay(pushPlusClosing.getSourceDayBudget().getDay())
+                .createdAt(pushPlusClosing.getCreatedAt())
+                .pushId(pushPlusClosing.getId());
+
+        // redistributionOption이 DATE일 때만 targetDay 설정
+        if (pushPlusClosing.getRedistributionOption() == RedistributionOption.DATE) {
+            builder.targetDay(pushPlusClosing.getTargetDayBudget().getDay());
+        }
+
+        return builder.build();
+    }
+
+    public static BudgetRedistributionResponseDTO.GetReceiptListDTO ToGetReceiptListDTO(List<Income> incomeList, List<Expenditure> expenditureList, List<PullMinusClosing> pullList, List<PushPlusClosing> pushList, Integer dayBudget, Long totalExpenditureAmount) {
+        List<BudgetRedistributionResponseDTO.GetIncomeDTO> toGetIncomeDTOList = incomeList.stream()
+                .map(BudgetRedistributionConverter::toGetIncomeDTO).toList();
+
+        List<BudgetRedistributionResponseDTO.GetExpenditureDTO> toGetExpenditureDTOList = expenditureList.stream()
+                .map(BudgetRedistributionConverter::toGetExpenditureDTO).toList();
+
+        List<BudgetRedistributionResponseDTO.GetPullDTO> toGetPullDTOList = pullList.stream()
+                .map(BudgetRedistributionConverter::toGetPullDTO).toList();
+
+        List<BudgetRedistributionResponseDTO.GetPushDTO> toGetPushDTOList = pushList.stream()
+                .map(BudgetRedistributionConverter::toGetPushDTO).toList();
+
+        return BudgetRedistributionResponseDTO.GetReceiptListDTO.builder()
+                .incomeList(toGetIncomeDTOList)
+                .expenditureList(toGetExpenditureDTOList)
+                .pullList(toGetPullDTOList)
+                .pushList(toGetPushDTOList)
+                .dayBudget(dayBudget)
+                .todayExpenditureAmount(totalExpenditureAmount)
+                .build();
+    }
+
+    public static BudgetRedistributionResponseDTO.GetClosingCheckDTO ToGetClosingCheckDTO(Boolean check) {
+        return BudgetRedistributionResponseDTO.GetClosingCheckDTO.builder()
+                .check(check)
+                .build();
+    }
+
+    public static BudgetRedistributionResponseDTO.GetClosingCheckLastDTO ToGetClosingCheckLastDTO(LocalDate last) {
+        return BudgetRedistributionResponseDTO.GetClosingCheckLastDTO.builder()
+                .year(last.getYear())
+                .month(last.getMonthValue())
+                .day(last.getDayOfMonth())
                 .build();
     }
 }

--- a/src/main/java/umc/haruchi/domain/Member.java
+++ b/src/main/java/umc/haruchi/domain/Member.java
@@ -6,6 +6,7 @@ import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 import umc.haruchi.domain.common.BaseEntity;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -30,6 +31,8 @@ public class Member extends BaseEntity {
 
     @Column(nullable = false)
     private String password;
+
+    private LocalDate lastClosing;
 
 //    @Enumerated(EnumType.STRING)
 //    @Column(nullable = false, columnDefinition = "VARCHAR(10) DEFAULT 'LOGOUT'") // LOGIN, LOGOUT
@@ -59,5 +62,9 @@ public class Member extends BaseEntity {
 
     public void subSafeBox(long safeBoxAmount) {
         safeBox -= safeBoxAmount;
+    }
+
+    public void setLastClosing() {
+        this.lastClosing = LocalDate.now();
     }
 }

--- a/src/main/java/umc/haruchi/repository/DayBudgetRepository.java
+++ b/src/main/java/umc/haruchi/repository/DayBudgetRepository.java
@@ -5,8 +5,10 @@ import org.springframework.security.authentication.jaas.JaasAuthenticationCallba
 import umc.haruchi.domain.DayBudget;
 import umc.haruchi.domain.MonthBudget;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface DayBudgetRepository extends JpaRepository<DayBudget, Long> {
     Optional<DayBudget> findByMonthBudgetAndDay(MonthBudget monthBudget, int day);
+    List<DayBudget> findByMonthBudget(MonthBudget monthBudget);
 }

--- a/src/main/java/umc/haruchi/repository/ExpenditureRepository.java
+++ b/src/main/java/umc/haruchi/repository/ExpenditureRepository.java
@@ -4,6 +4,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import umc.haruchi.domain.DayBudget;
 import umc.haruchi.domain.Expenditure;
 
+import java.util.List;
+
 public interface ExpenditureRepository extends JpaRepository<Expenditure, Integer> {
     Expenditure findByDayBudgetAndId(DayBudget dayBudget, Long memberId);
+    List<Expenditure> findByDayBudget(DayBudget dayBudget);
 }

--- a/src/main/java/umc/haruchi/repository/IncomeRepository.java
+++ b/src/main/java/umc/haruchi/repository/IncomeRepository.java
@@ -4,7 +4,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import umc.haruchi.domain.DayBudget;
 import umc.haruchi.domain.Income;
 
+import java.util.List;
+
 public interface IncomeRepository extends JpaRepository<Income, Integer> {
 
     Income findByDayBudgetAndId(DayBudget dayBudget, Long memberId);
+    List<Income> findByDayBudget(DayBudget dayBudget);
 }

--- a/src/main/java/umc/haruchi/repository/PullMinusClosingRepository.java
+++ b/src/main/java/umc/haruchi/repository/PullMinusClosingRepository.java
@@ -1,8 +1,12 @@
 package umc.haruchi.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import umc.haruchi.domain.DayBudget;
 import umc.haruchi.domain.PullMinusClosing;
-import umc.haruchi.domain.PushPlusClosing;
+
+import java.util.List;
 
 public interface PullMinusClosingRepository extends JpaRepository<PullMinusClosing, Long> {
+    List<PullMinusClosing> findByTargetDayBudgetAndClosingOptionIsFalse(DayBudget targetDayBudget);
+    List<PullMinusClosing> findByTargetDayBudgetAndClosingOptionIsTrue(DayBudget targetDayBudget);
 }

--- a/src/main/java/umc/haruchi/repository/PushPlusClosingRepository.java
+++ b/src/main/java/umc/haruchi/repository/PushPlusClosingRepository.java
@@ -1,7 +1,12 @@
 package umc.haruchi.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import umc.haruchi.domain.DayBudget;
 import umc.haruchi.domain.PushPlusClosing;
 
+import java.util.List;
+
 public interface PushPlusClosingRepository extends JpaRepository<PushPlusClosing, Long> {
+    List<PushPlusClosing> findBySourceDayBudgetAndClosingOptionIsFalse(DayBudget dayBudget);
+    List<PushPlusClosing> findBySourceDayBudgetAndClosingOptionIsTrue(DayBudget dayBudget);
 }

--- a/src/main/java/umc/haruchi/service/BudgetRedistributionService.java
+++ b/src/main/java/umc/haruchi/service/BudgetRedistributionService.java
@@ -13,6 +13,8 @@ import umc.haruchi.domain.enums.DayBudgetStatus;
 import umc.haruchi.repository.*;
 import umc.haruchi.web.dto.BudgetRedistributionRequestDTO;
 import java.time.LocalDate;
+import java.util.List;
+
 import static umc.haruchi.apiPayload.code.status.ErrorStatus.*;
 import static umc.haruchi.domain.enums.RedistributionOption.*;
 
@@ -26,6 +28,8 @@ public class BudgetRedistributionService {
     private final PushPlusClosingRepository pushPlusClosingRepository;
     private final PullMinusClosingRepository pullMinusClosingRepository;
     private final MemberRepository memberRepository;
+    private final IncomeRepository incomeRepository;
+    private final ExpenditureRepository expenditureRepository;
 
     LocalDate now = LocalDate.now(); // 현재 날짜 가져오기
     int year = now.getYear();
@@ -386,6 +390,7 @@ public class BudgetRedistributionService {
         }
         PushPlusClosing pushPlusClosing = BudgetRedistributionConverter.toPlusClosing(request, dayBudget);
         dayBudget.changeDayBudgetStatus(); //INACTIVE로 변경
+        member.setLastClosing();
         return pushPlusClosingRepository.save(pushPlusClosing);
     }
 
@@ -478,6 +483,7 @@ public class BudgetRedistributionService {
         dayBudget.subAmount(dayBudget.getDayBudget()); // 양수일 때도 음수일 때도 0이 됨
         PullMinusClosing pullMinusClosing = BudgetRedistributionConverter.toMinusClosing(request, dayBudget);
         dayBudget.changeDayBudgetStatus(); //INACTIVE로 변경
+        member.setLastClosing();
         return pullMinusClosingRepository.save(pullMinusClosing);
     }
 
@@ -508,5 +514,75 @@ public class BudgetRedistributionService {
             //0이면 1/n 요청 들어올 수 x
             throw new BudgetRedistributionHandler(ZERO_AMOUNT);
         }
+    }
+
+    public List<Income> getIncomeList(int year, int month, int day, Long memberId) {
+        MonthBudget monthBudget = monthBudgetRepository.findByMemberIdAndYearAndMonth(memberId, year, month)
+                .orElseThrow(() -> new MonthBudgetHandler(MONTH_BUDGET_NOT_FOUND));
+        DayBudget dayBudget = dayBudgetRepository.findByMonthBudgetAndDay(monthBudget, day)
+                .orElseThrow(() -> new DayBudgetHandler(NOT_SOME_DAY_BUDGET));
+        return incomeRepository.findByDayBudget(dayBudget);
+    }
+
+    public List<Expenditure> getExpenditureList(int year, int month, int day, Long memberId) {
+        MonthBudget monthBudget = monthBudgetRepository.findByMemberIdAndYearAndMonth(memberId, year, month)
+                .orElseThrow(() -> new MonthBudgetHandler(MONTH_BUDGET_NOT_FOUND));
+        DayBudget dayBudget = dayBudgetRepository.findByMonthBudgetAndDay(monthBudget, day)
+                .orElseThrow(() -> new DayBudgetHandler(NOT_SOME_DAY_BUDGET));
+        return expenditureRepository.findByDayBudget(dayBudget);
+    }
+
+    public List<PullMinusClosing> getPullList(int year, int month, int day, Long memberId) {
+        MonthBudget monthBudget = monthBudgetRepository.findByMemberIdAndYearAndMonth(memberId, year, month)
+                .orElseThrow(() -> new MonthBudgetHandler(MONTH_BUDGET_NOT_FOUND));
+        DayBudget dayBudget = dayBudgetRepository.findByMonthBudgetAndDay(monthBudget, day)
+                .orElseThrow(() -> new DayBudgetHandler(NOT_SOME_DAY_BUDGET));
+        return pullMinusClosingRepository.findByTargetDayBudgetAndClosingOptionIsFalse(dayBudget);
+    }
+
+    public List<PushPlusClosing> getPushList(int year, int month, int day, Long memberId) {
+        MonthBudget monthBudget = monthBudgetRepository.findByMemberIdAndYearAndMonth(memberId, year, month)
+                .orElseThrow(() -> new MonthBudgetHandler(MONTH_BUDGET_NOT_FOUND));
+        DayBudget dayBudget = dayBudgetRepository.findByMonthBudgetAndDay(monthBudget, day)
+                .orElseThrow(() -> new DayBudgetHandler(NOT_SOME_DAY_BUDGET));
+        return pushPlusClosingRepository.findBySourceDayBudgetAndClosingOptionIsFalse(dayBudget);
+    }
+
+    public Integer getDayBudget(int year, int month, int day, Long memberId) {
+        MonthBudget monthBudget = monthBudgetRepository.findByMemberIdAndYearAndMonth(memberId, year, month)
+                .orElseThrow(() -> new MonthBudgetHandler(MONTH_BUDGET_NOT_FOUND));
+        DayBudget dayBudget = dayBudgetRepository.findByMonthBudgetAndDay(monthBudget, day)
+                .orElseThrow(() -> new DayBudgetHandler(NOT_SOME_DAY_BUDGET));
+        return dayBudget.getDayBudget();
+    }
+
+    public Long getTotalExpenditureAmount(int year, int month, int day, Long memberId) {
+        List<Expenditure> expenditureList = getExpenditureList(year, month, day, memberId);
+        long sum = expenditureList.stream().mapToLong(e -> e.getExpenditureAmount()).sum();
+        return sum;
+    }
+
+    public Boolean closingCheck(int year, int month, int day, Long memberId) {
+        MonthBudget monthBudget = monthBudgetRepository.findByMemberIdAndYearAndMonth(memberId, year, month)
+                .orElseThrow(() -> new MonthBudgetHandler(MONTH_BUDGET_NOT_FOUND));
+        DayBudget dayBudget = dayBudgetRepository.findByMonthBudgetAndDay(monthBudget, day)
+                .orElseThrow(() -> new DayBudgetHandler(NOT_SOME_DAY_BUDGET));
+        if(!pullMinusClosingRepository.findByTargetDayBudgetAndClosingOptionIsTrue(dayBudget).isEmpty()) {
+            return true;
+        }
+        else if(!pushPlusClosingRepository.findBySourceDayBudgetAndClosingOptionIsTrue(dayBudget).isEmpty()) {
+            return true;
+        }
+        return false;
+    }
+
+    public LocalDate closingCheckLast(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(NO_MEMBER_EXIST)); //영속화
+        LocalDate lastClosing = member.getLastClosing();
+        if(lastClosing == null) {
+            throw new BudgetRedistributionHandler(NOTHING_CLOSING);
+        }
+        return lastClosing;
     }
 }

--- a/src/main/java/umc/haruchi/web/controller/BudgetRedistributionController.java
+++ b/src/main/java/umc/haruchi/web/controller/BudgetRedistributionController.java
@@ -9,11 +9,13 @@ import org.springframework.web.bind.annotation.*;
 import umc.haruchi.apiPayload.ApiResponse;
 import umc.haruchi.config.login.auth.MemberDetail;
 import umc.haruchi.converter.BudgetRedistributionConverter;
-import umc.haruchi.domain.PullMinusClosing;
-import umc.haruchi.domain.PushPlusClosing;
+import umc.haruchi.domain.*;
 import umc.haruchi.service.BudgetRedistributionService;
 import umc.haruchi.web.dto.BudgetRedistributionRequestDTO;
 import umc.haruchi.web.dto.BudgetRedistributionResponseDTO;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,42 +26,74 @@ public class BudgetRedistributionController {
 
     @Operation(summary = "넘겨쓰기 API", description = "EVENLY(1/n),DATE(특정일),SAFEBOX(targetId null)")
     @PostMapping("/push")
-    public ApiResponse<BudgetRedistributionResponseDTO.budgetPushResultDTO> pushBudget(@Valid @RequestBody BudgetRedistributionRequestDTO.createPushDTO request,
+    public ApiResponse<BudgetRedistributionResponseDTO.BudgetPushResultDTO> pushBudget(@Valid @RequestBody BudgetRedistributionRequestDTO.createPushDTO request,
                                                                                        @AuthenticationPrincipal MemberDetail memberDetail){
         PushPlusClosing pushPlusClosing = budgetRedistributionService.push(request, memberDetail.getMember().getId());
-        return ApiResponse.onSuccess(BudgetRedistributionConverter.ToBudgetPushResultDTO(pushPlusClosing));
+        return ApiResponse.onSuccess(BudgetRedistributionConverter.toBudgetPushResultDTO(pushPlusClosing));
     }
 
     @Operation(summary = "당겨쓰기 API", description = "EVENLY(1/n),DATE(특정일),SAFEBOX(sourceId null)")
     @PostMapping("/pull")
-    public ApiResponse<BudgetRedistributionResponseDTO.budgetPullResultDTO> pullBudget(@Valid @RequestBody BudgetRedistributionRequestDTO.createPullDTO request,
+    public ApiResponse<BudgetRedistributionResponseDTO.BudgetPullResultDTO> pullBudget(@Valid @RequestBody BudgetRedistributionRequestDTO.createPullDTO request,
                                                                                        @AuthenticationPrincipal MemberDetail memberDetail){
         PullMinusClosing pushMinusClosing = budgetRedistributionService.pull(request, memberDetail.getMember().getId());
-        return ApiResponse.onSuccess(BudgetRedistributionConverter.ToBudgetPullResultDTO(pushMinusClosing));
+        return ApiResponse.onSuccess(BudgetRedistributionConverter.toBudgetPullResultDTO(pushMinusClosing));
     }
 
     @Operation(summary = "지출 마감 API", description = "음수,양수,0으로 넘겨주시고, 0일 떄 옵션(EVENLY,SAFEBOX)은 ZERO로 넘겨주세요")
     @PostMapping("/closing")
-    public ApiResponse<BudgetRedistributionResponseDTO.budgetClosingResultDTO> closingBudget(@Valid @RequestBody BudgetRedistributionRequestDTO.createClosingDTO request,
+    public ApiResponse<BudgetRedistributionResponseDTO.BudgetClosingResultDTO> closingBudget(@Valid @RequestBody BudgetRedistributionRequestDTO.createClosingDTO request,
                                                                                              @AuthenticationPrincipal MemberDetail memberDetail){
         if(request.getAmount() >= 0) {
             PushPlusClosing pushPlusClosing = budgetRedistributionService.closingPlusOrZero(request, memberDetail.getMember().getId());
-            return ApiResponse.onSuccess(BudgetRedistributionConverter.ToBudgetClosingResultDTO(pushPlusClosing));
+            return ApiResponse.onSuccess(BudgetRedistributionConverter.toBudgetClosingResultDTO(pushPlusClosing));
         }
         else {
             PullMinusClosing pullMinusClosing = budgetRedistributionService.closingMinus(request, memberDetail.getMember().getId());
-            return ApiResponse.onSuccess(BudgetRedistributionConverter.ToBudgetClosingResultDTO(pullMinusClosing));
+            return ApiResponse.onSuccess(BudgetRedistributionConverter.toBudgetClosingResultDTO(pullMinusClosing));
         }
     }
 
     @Operation(summary = "지출 마감에서 1/n경우의 하루 차감/분배 값 조회 API", description = "지출 마감 영수증에서 고르게 분배하기 선택 시 얼마씩 분배/차감할 지 알려주는 API입니다. +, - 값을 넘겨주세요.")
     @GetMapping("/closing/amount")
-    public ApiResponse<BudgetRedistributionResponseDTO.getCalculatedAmountResultDTO> getCalculatedAmount(@RequestParam @NotNull(message = "year 값은 필수 입력 값입니다.") int year,
+    public ApiResponse<BudgetRedistributionResponseDTO.GetCalculatedAmountResultDTO> getCalculatedAmount(@RequestParam @NotNull(message = "year 값은 필수 입력 값입니다.") int year,
                                                                                                          @RequestParam @NotNull(message = "month 값은 필수 입력 값입니다.") int month,
                                                                                                          @RequestParam @NotNull(message = "day 값은 필수 입력 값입니다.") int day,
                                                                                                          @RequestParam @NotNull(message = "amount 값은 필수 입력 값입니다.") Long amount,
-                                                                                          @AuthenticationPrincipal MemberDetail memberDetail){
+                                                                                                         @AuthenticationPrincipal MemberDetail memberDetail){
         Long calculatedAmount = budgetRedistributionService.calculatingAmount(year, month, day, amount, memberDetail.getMember().getId());
-        return ApiResponse.onSuccess(BudgetRedistributionConverter.ToGetCalculatedAmountResultDTO(calculatedAmount));
+        return ApiResponse.onSuccess(BudgetRedistributionConverter.toGetCalculatedAmountResultDTO(calculatedAmount));
+    }
+
+    @Operation(summary = "지출 영수증 조회 API", description = "지출 영수증 조회 API입니다.")
+    @GetMapping("/closing")
+    public ApiResponse<BudgetRedistributionResponseDTO.GetReceiptListDTO> getReceipt(@RequestParam @NotNull(message = "year 값은 필수 입력 값입니다.") int year,
+                                                                                     @RequestParam @NotNull(message = "month 값은 필수 입력 값입니다.") int month,
+                                                                                     @RequestParam @NotNull(message = "day 값은 필수 입력 값입니다.") int day,
+                                                                                     @AuthenticationPrincipal MemberDetail memberDetail){
+        List<Income> incomeList = budgetRedistributionService.getIncomeList(year, month, day, memberDetail.getMember().getId());
+        List<Expenditure> expenditureList = budgetRedistributionService.getExpenditureList(year, month, day, memberDetail.getMember().getId());
+        List<PullMinusClosing> pullList = budgetRedistributionService.getPullList(year, month, day, memberDetail.getMember().getId());
+        List<PushPlusClosing> pushList = budgetRedistributionService.getPushList(year, month, day, memberDetail.getMember().getId());
+        Integer dayBudget = budgetRedistributionService.getDayBudget(year, month, day, memberDetail.getMember().getId());
+        Long totalExpenditureAmount = budgetRedistributionService.getTotalExpenditureAmount(year, month, day, memberDetail.getMember().getId());
+        return ApiResponse.onSuccess(BudgetRedistributionConverter.ToGetReceiptListDTO(incomeList, expenditureList, pullList, pushList, dayBudget, totalExpenditureAmount));
+    }
+
+    @Operation(summary = "지출 마감 확인 API", description = "true면 지출 마감, false면 마감 x")
+    @GetMapping("/closing/check")
+    public ApiResponse<BudgetRedistributionResponseDTO.GetClosingCheckDTO> getClosingCheck(@RequestParam @NotNull(message = "year 값은 필수 입력 값입니다.") int year,
+                                                                                           @RequestParam @NotNull(message = "month 값은 필수 입력 값입니다.") int month,
+                                                                                           @RequestParam @NotNull(message = "day 값은 필수 입력 값입니다.") int day,
+                                                                                           @AuthenticationPrincipal MemberDetail memberDetail){
+        Boolean check = budgetRedistributionService.closingCheck(year, month, day, memberDetail.getMember().getId());
+        return ApiResponse.onSuccess(BudgetRedistributionConverter.ToGetClosingCheckDTO(check));
+    }
+
+    @Operation(summary = "마지막 지출 마감일 확인 API", description = "마지막 지출 마감일 확인 API")
+    @GetMapping("/closing/check/last")
+    public ApiResponse<BudgetRedistributionResponseDTO.GetClosingCheckLastDTO> getClosingCheckLast(@AuthenticationPrincipal MemberDetail memberDetail){
+        LocalDate last = budgetRedistributionService.closingCheckLast(memberDetail.getMember().getId());
+        return ApiResponse.onSuccess(BudgetRedistributionConverter.ToGetClosingCheckLastDTO(last));
     }
 }

--- a/src/main/java/umc/haruchi/web/controller/BudgetRedistributionController.java
+++ b/src/main/java/umc/haruchi/web/controller/BudgetRedistributionController.java
@@ -40,11 +40,26 @@ public class BudgetRedistributionController {
         return ApiResponse.onSuccess(BudgetRedistributionConverter.toBudgetPullResultDTO(pushMinusClosing));
     }
 
-    @Operation(summary = "지출 마감 API", description = "음수,양수,0으로 넘겨주시고, 0일 떄 옵션(EVENLY,SAFEBOX)은 ZERO로 넘겨주세요")
+//    @Operation(summary = "지출 마감 API", description = "음수,양수,0으로 넘겨주시고, 0일 떄 옵션(EVENLY,SAFEBOX)은 ZERO로 넘겨주세요")
+//    @PostMapping("/closing")
+//    public ApiResponse<BudgetRedistributionResponseDTO.BudgetClosingResultDTO> closingBudget(@Valid @RequestBody BudgetRedistributionRequestDTO.createClosingDTO request,
+//                                                                                             @AuthenticationPrincipal MemberDetail memberDetail){
+//        if(request.getAmount() >= 0) {
+//            PushPlusClosing pushPlusClosing = budgetRedistributionService.closingPlusOrZero(request, memberDetail.getMember().getId());
+//            return ApiResponse.onSuccess(BudgetRedistributionConverter.toBudgetClosingResultDTO(pushPlusClosing));
+//        }
+//        else {
+//            PullMinusClosing pullMinusClosing = budgetRedistributionService.closingMinus(request, memberDetail.getMember().getId());
+//            return ApiResponse.onSuccess(BudgetRedistributionConverter.toBudgetClosingResultDTO(pullMinusClosing));
+//        }
+//    }
+
+    @Operation(summary = "지출 마감 API", description = "0일때는 1/n 에러처리 되어있습니다.")
     @PostMapping("/closing")
     public ApiResponse<BudgetRedistributionResponseDTO.BudgetClosingResultDTO> closingBudget(@Valid @RequestBody BudgetRedistributionRequestDTO.createClosingDTO request,
                                                                                              @AuthenticationPrincipal MemberDetail memberDetail){
-        if(request.getAmount() >= 0) {
+        boolean plusOrZeroOrMinus = budgetRedistributionService.plusOrZeroOrMinus(request, memberDetail.getMember().getId());
+        if(plusOrZeroOrMinus) {
             PushPlusClosing pushPlusClosing = budgetRedistributionService.closingPlusOrZero(request, memberDetail.getMember().getId());
             return ApiResponse.onSuccess(BudgetRedistributionConverter.toBudgetClosingResultDTO(pushPlusClosing));
         }

--- a/src/main/java/umc/haruchi/web/controller/BudgetRedistributionController.java
+++ b/src/main/java/umc/haruchi/web/controller/BudgetRedistributionController.java
@@ -54,7 +54,7 @@ public class BudgetRedistributionController {
 //        }
 //    }
 
-    @Operation(summary = "지출 마감 API", description = "0일때는 1/n 에러처리 되어있습니다.")
+    @Operation(summary = "지출 마감 API", description = "0일떄는 옵션을 ZERO로 넘겨주시고, 마지막 날의 1/n 방식은 에러처리 되어있습니다.")
     @PostMapping("/closing")
     public ApiResponse<BudgetRedistributionResponseDTO.BudgetClosingResultDTO> closingBudget(@Valid @RequestBody BudgetRedistributionRequestDTO.createClosingDTO request,
                                                                                              @AuthenticationPrincipal MemberDetail memberDetail){

--- a/src/main/java/umc/haruchi/web/dto/BudgetRedistributionRequestDTO.java
+++ b/src/main/java/umc/haruchi/web/dto/BudgetRedistributionRequestDTO.java
@@ -64,8 +64,5 @@ public class BudgetRedistributionRequestDTO {
 
         @NotNull(message = "day 값은 필수 입력 값입니다.")
         int day;
-
-        @NotNull(message = "amount 값은 필수 입력 값입니다.")
-        Long amount;
     }
 }

--- a/src/main/java/umc/haruchi/web/dto/BudgetRedistributionResponseDTO.java
+++ b/src/main/java/umc/haruchi/web/dto/BudgetRedistributionResponseDTO.java
@@ -4,8 +4,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import umc.haruchi.domain.enums.ExpenditureCategory;
+import umc.haruchi.domain.enums.IncomeCategory;
+import umc.haruchi.domain.enums.RedistributionOption;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 
 public class BudgetRedistributionResponseDTO {
 
@@ -13,34 +18,111 @@ public class BudgetRedistributionResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class budgetPushResultDTO {
+    public static class BudgetPushResultDTO {
         Long pushId;
-        LocalDate createdAt;
+        LocalDateTime createdAt;
     }
 
     @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class budgetPullResultDTO {
+    public static class BudgetPullResultDTO {
         Long pullId;
-        LocalDate createdAt;
+        LocalDateTime createdAt;
     }
 
     @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class budgetClosingResultDTO {
+    public static class BudgetClosingResultDTO {
         Long closingId;
-        LocalDate createdAt;
+        LocalDateTime createdAt;
     }
 
     @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class getCalculatedAmountResultDTO {
+    public static class GetCalculatedAmountResultDTO {
         Long calculatedAmount;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetIncomeDTO {
+        IncomeCategory incomeCategory;
+        Long incomeAmount;
+        Long incomeId;
+        LocalDateTime createdAt;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetExpenditureDTO {
+        ExpenditureCategory expenditureCategory;
+        Long expenditureAmount;
+        Long expenditureId;
+        LocalDateTime createdAt;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetPullDTO {
+        RedistributionOption redistributionOption;
+        Long sourceDay; //여기서
+        Long targetDay; //여기로 당겨왔다
+        Long pullId;
+        LocalDateTime createdAt;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetPushDTO {
+        RedistributionOption redistributionOption;
+        Long sourceDay; //여기서
+        Long targetDay; //여기로 당겨왔다
+        Long pushId;
+        LocalDateTime createdAt;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetReceiptListDTO {
+        Integer dayBudget; // 오늘 최종 하루치
+        Long todayExpenditureAmount; // 지출 총 합
+        List<GetIncomeDTO> incomeList;
+        List<GetExpenditureDTO> expenditureList;
+        List<GetPullDTO> pullList;
+        List<GetPushDTO> pushList;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetClosingCheckDTO {
+        Boolean check;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetClosingCheckLastDTO {
+        Integer year;
+        Integer month;
+        Integer day;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,7 +26,8 @@ spring:
 
   data:
     redis:
-      host: ${AWS_REDIS_HOST} #로컬로 실행할 때에는 로컬 Redis 서버로만 테스트 가능. 연동 x
+#      host: ${AWS_REDIS_HOST} #로컬로 실행할 때에는 로컬 Redis 서버로만 테스트 가능. 연동 x
+      host: localhost
       port: 6379
 
   cache:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,8 +26,7 @@ spring:
 
   data:
     redis:
-#      host: ${AWS_REDIS_HOST} #로컬로 실행할 때에는 로컬 Redis 서버로만 테스트 가능. 연동 x
-      host: localhost
+      host: ${AWS_REDIS_HOST} #로컬로 실행할 때에는 로컬 Redis 서버로만 테스트 가능. 연동 x
       port: 6379
 
   cache:


### PR DESCRIPTION
## 💡 관련 이슈

#40 

## 📢 작업 내용

- 지출 영수증 조회 API (총 지출, dayBudget, 지출 내역, 수입내역, 당기기, 넘기기 내역) 
- 지출 마감 확인 API -> 추가 
- 마지막 지출 마감일 확인 API -> 추가 (member에 컬럼 만들어서 지출 마감할때마다 업데이트 되도록 했습니다.)
- 지출 마감 로직을 amount를 직접 받지않고 저장된 하루예산을 이용하는 방식으로 변경했습니다. 

## 🗨️ 리뷰 요구사항(선택)

.

## ✅ 체크리스트

- [x]  코드가 정상적으로 컴파일되나요?
- [x]  이슈 내용을 전부 구현했나요?
- [x]  작업 기간 내에 개발을 완료했나요?
- [x]  리뷰어를 선택했나요?
- [x]  라벨을 지정했나요?
