### PR TITLE
[FIX] 한 주 예산 조회 리스트에 closingState추가, API 수정 

### DIFF
--- a/src/main/java/umc/haruchi/converter/MonthBudgetConverter.java
+++ b/src/main/java/umc/haruchi/converter/MonthBudgetConverter.java
@@ -2,6 +2,7 @@ package umc.haruchi.converter;
 
 import umc.haruchi.domain.DayBudget;
 import umc.haruchi.domain.MonthBudget;
+import umc.haruchi.domain.enums.DayBudgetStatus;
 import umc.haruchi.web.dto.MonthBudgetRequestDTO;
 import umc.haruchi.web.dto.MonthBudgetResponseDTO;
 
@@ -56,6 +57,7 @@ public class MonthBudgetConverter {
                 .day(dayBudget.getDay())
                 .dayBudget(dayBudget.getDayBudget())
                 .status(dayBudget.getDayBudgetStatus())
+                .closingState(dayBudget.getClosingStatus())
                 .build();
     }
 

--- a/src/main/java/umc/haruchi/domain/DayBudget.java
+++ b/src/main/java/umc/haruchi/domain/DayBudget.java
@@ -6,6 +6,7 @@ import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 import umc.haruchi.domain.common.BaseEntity;
+import umc.haruchi.domain.enums.ClosingStatus;
 import umc.haruchi.domain.enums.DayBudgetStatus;
 
 import java.time.LocalDate;
@@ -32,6 +33,10 @@ public class DayBudget extends BaseEntity {
     @Column(nullable = false)
     @ColumnDefault("0")
     private Integer dayBudget;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, columnDefinition = "VARCHAR(10) DEFAULT 'ETC'")
+    private ClosingStatus closingStatus;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, columnDefinition = "VARCHAR(10) DEFAULT 'ACTIVE'")
@@ -103,5 +108,9 @@ public class DayBudget extends BaseEntity {
 
     public void changeDayBudgetStatus() {
         dayBudgetStatus = DayBudgetStatus.INACTIVE;
+    }
+
+    public void setClosingStatus(ClosingStatus closingStatus) {
+        this.closingStatus = closingStatus;
     }
 }

--- a/src/main/java/umc/haruchi/domain/enums/ClosingStatus.java
+++ b/src/main/java/umc/haruchi/domain/enums/ClosingStatus.java
@@ -1,0 +1,5 @@
+package umc.haruchi.domain.enums;
+
+public enum ClosingStatus {
+    ZERO, PLUS, MINUS, ETC
+}

--- a/src/main/java/umc/haruchi/service/BudgetRedistributionService.java
+++ b/src/main/java/umc/haruchi/service/BudgetRedistributionService.java
@@ -9,6 +9,7 @@ import umc.haruchi.apiPayload.exception.handler.MemberHandler;
 import umc.haruchi.apiPayload.exception.handler.MonthBudgetHandler;
 import umc.haruchi.converter.BudgetRedistributionConverter;
 import umc.haruchi.domain.*;
+import umc.haruchi.domain.enums.ClosingStatus;
 import umc.haruchi.domain.enums.DayBudgetStatus;
 import umc.haruchi.repository.*;
 import umc.haruchi.web.dto.BudgetRedistributionRequestDTO;
@@ -347,8 +348,15 @@ public class BudgetRedistributionService {
 
         long totalAmount = dayBudget.getDayBudget();
 
+        if(dayBudget.getDayBudget() > 0) {
+            dayBudget.setClosingStatus(ClosingStatus.PLUS);
+        } else {
+            dayBudget.setClosingStatus(ClosingStatus.ZERO);
+        }
+
         //분배
         if (dayBudget.getDayBudget() > 0) {
+
             //고르게 넘기기(233원씩 넘겨준다고하면 200원씩 분배하고 33원씩 * 일수 -> 세이프박스)
             //dayCount가 0일때 -> 마지막 날일 때 예외처리
             if(dayCount == 0) {
@@ -393,19 +401,19 @@ public class BudgetRedistributionService {
                                 budget.subAmount(budget.getDayBudget() % 100);
                             }
                         });
-
-                dayBudget.subAmount(dayBudget.getDayBudget()); //dayBudget의 amount는 0으로
                 member.addSafeBox(safeBoxAmount);
 
             } else if (request.getRedistributionOption().equals(SAFEBOX)) {
                 // 세이프 박스에 넘기기(233원을 넘겨준다고하면 233그대로 넘김)
                 // 세이프박스에 저장
                 member.addSafeBox(totalAmount);
-                dayBudget.subAmount(dayBudget.getDayBudget()); //dayBudget의 amount는 0으로
             }
         }
+
+        dayBudget.subAmount(dayBudget.getDayBudget()); //dayBudget의 amount는 0으로
         PushPlusClosing pushPlusClosing = BudgetRedistributionConverter.toPlusClosing(request, dayBudget);
         dayBudget.changeDayBudgetStatus(); //INACTIVE로 변경
+
         member.setLastClosing();
         return pushPlusClosingRepository.save(pushPlusClosing);
     }
@@ -494,7 +502,7 @@ public class BudgetRedistributionService {
             // 세이프박스에서 차감
             member.subSafeBox(totalAmount);
         }
-
+        dayBudget.setClosingStatus(ClosingStatus.MINUS);
         member.addSafeBox(safeBoxAmount);
         dayBudget.subAmount(dayBudget.getDayBudget()); // 양수일 때도 음수일 때도 0이 됨
         PullMinusClosing pullMinusClosing = BudgetRedistributionConverter.toMinusClosing(request, dayBudget);

--- a/src/main/java/umc/haruchi/service/BudgetRedistributionService.java
+++ b/src/main/java/umc/haruchi/service/BudgetRedistributionService.java
@@ -511,10 +511,13 @@ public class BudgetRedistributionService {
         return pullMinusClosingRepository.save(pullMinusClosing);
     }
 
-    public Long calculatingAmount(int year, int month, int day, Long amount, Long memberId) {
+    public Long calculatingAmount(int year, int month, int day, Long memberId) {
 
         MonthBudget monthBudget = monthBudgetRepository.findByMemberIdAndYearAndMonth(memberId, year, month)
                 .orElseThrow(() -> new MonthBudgetHandler(MONTH_BUDGET_NOT_FOUND));
+
+        DayBudget dayBudget = dayBudgetRepository.findByMonthBudgetAndDay(monthBudget, day)
+                .orElseThrow(() -> new DayBudgetHandler(NOT_SOME_DAY_BUDGET));
 
         //이번 달 남은 일 수 알아내기(본인 제외)
         long dayCount = monthBudget.getDayBudgetList().stream()
@@ -525,13 +528,13 @@ public class BudgetRedistributionService {
             throw new BudgetRedistributionHandler(FINAL_DAY);
         }
 
-        long totalAmount = amount;
+        long totalAmount = dayBudget.getDayBudget();
 
-        if(amount > 0) {
+        if(totalAmount > 0) {
             return totalAmount / dayCount;
         }
-        else if(amount < 0) {
-            totalAmount = -1 * amount; //양수로 변경
+        else if(totalAmount < 0) {
+            totalAmount = -1 * totalAmount; //양수로 변경
             return totalAmount / dayCount;
         }
         else {

--- a/src/main/java/umc/haruchi/web/controller/BudgetRedistributionController.java
+++ b/src/main/java/umc/haruchi/web/controller/BudgetRedistributionController.java
@@ -24,7 +24,7 @@ public class BudgetRedistributionController {
 
     private final BudgetRedistributionService budgetRedistributionService;
 
-    @Operation(summary = "넘겨쓰기 API", description = "EVENLY(1/n),DATE(특정일),SAFEBOX(targetId null)")
+    @Operation(summary = "넘겨쓰기 API", description = "DATE(특정일)을 제외한 EVENLY(1/n) 와 SAFEBOX는 targetId를 null로 넘겨주세요")
     @PostMapping("/push")
     public ApiResponse<BudgetRedistributionResponseDTO.BudgetPushResultDTO> pushBudget(@Valid @RequestBody BudgetRedistributionRequestDTO.createPushDTO request,
                                                                                        @AuthenticationPrincipal MemberDetail memberDetail){
@@ -32,7 +32,7 @@ public class BudgetRedistributionController {
         return ApiResponse.onSuccess(BudgetRedistributionConverter.toBudgetPushResultDTO(pushPlusClosing));
     }
 
-    @Operation(summary = "당겨쓰기 API", description = "EVENLY(1/n),DATE(특정일),SAFEBOX(sourceId null)")
+    @Operation(summary = "당겨쓰기 API", description = "DATE(특정일)을 제외한 EVENLY(1/n) 와 SAFEBOX는 sourceId를 null로 넘겨주세요")
     @PostMapping("/pull")
     public ApiResponse<BudgetRedistributionResponseDTO.BudgetPullResultDTO> pullBudget(@Valid @RequestBody BudgetRedistributionRequestDTO.createPullDTO request,
                                                                                        @AuthenticationPrincipal MemberDetail memberDetail){

--- a/src/main/java/umc/haruchi/web/controller/BudgetRedistributionController.java
+++ b/src/main/java/umc/haruchi/web/controller/BudgetRedistributionController.java
@@ -40,20 +40,6 @@ public class BudgetRedistributionController {
         return ApiResponse.onSuccess(BudgetRedistributionConverter.toBudgetPullResultDTO(pushMinusClosing));
     }
 
-//    @Operation(summary = "지출 마감 API", description = "음수,양수,0으로 넘겨주시고, 0일 떄 옵션(EVENLY,SAFEBOX)은 ZERO로 넘겨주세요")
-//    @PostMapping("/closing")
-//    public ApiResponse<BudgetRedistributionResponseDTO.BudgetClosingResultDTO> closingBudget(@Valid @RequestBody BudgetRedistributionRequestDTO.createClosingDTO request,
-//                                                                                             @AuthenticationPrincipal MemberDetail memberDetail){
-//        if(request.getAmount() >= 0) {
-//            PushPlusClosing pushPlusClosing = budgetRedistributionService.closingPlusOrZero(request, memberDetail.getMember().getId());
-//            return ApiResponse.onSuccess(BudgetRedistributionConverter.toBudgetClosingResultDTO(pushPlusClosing));
-//        }
-//        else {
-//            PullMinusClosing pullMinusClosing = budgetRedistributionService.closingMinus(request, memberDetail.getMember().getId());
-//            return ApiResponse.onSuccess(BudgetRedistributionConverter.toBudgetClosingResultDTO(pullMinusClosing));
-//        }
-//    }
-
     @Operation(summary = "지출 마감 API", description = "0일떄는 옵션을 ZERO로 넘겨주시고, 마지막 날의 1/n 방식은 에러처리 되어있습니다.")
     @PostMapping("/closing")
     public ApiResponse<BudgetRedistributionResponseDTO.BudgetClosingResultDTO> closingBudget(@Valid @RequestBody BudgetRedistributionRequestDTO.createClosingDTO request,
@@ -69,14 +55,13 @@ public class BudgetRedistributionController {
         }
     }
 
-    @Operation(summary = "지출 마감에서 1/n경우의 하루 차감/분배 값 조회 API", description = "지출 마감 영수증에서 고르게 분배하기 선택 시 얼마씩 분배/차감할 지 알려주는 API입니다. +, - 값을 넘겨주세요.")
+    @Operation(summary = "지출 마감에서 1/n경우의 하루 차감/분배 값 조회 API", description = "지출 마감 영수증에서 고르게 분배하기 선택 시 얼마씩 분배/차감할 지 알려주는 API입니다.")
     @GetMapping("/closing/amount")
     public ApiResponse<BudgetRedistributionResponseDTO.GetCalculatedAmountResultDTO> getCalculatedAmount(@RequestParam @NotNull(message = "year 값은 필수 입력 값입니다.") int year,
                                                                                                          @RequestParam @NotNull(message = "month 값은 필수 입력 값입니다.") int month,
                                                                                                          @RequestParam @NotNull(message = "day 값은 필수 입력 값입니다.") int day,
-                                                                                                         @RequestParam @NotNull(message = "amount 값은 필수 입력 값입니다.") Long amount,
                                                                                                          @AuthenticationPrincipal MemberDetail memberDetail){
-        Long calculatedAmount = budgetRedistributionService.calculatingAmount(year, month, day, amount, memberDetail.getMember().getId());
+        Long calculatedAmount = budgetRedistributionService.calculatingAmount(year, month, day, memberDetail.getMember().getId());
         return ApiResponse.onSuccess(BudgetRedistributionConverter.toGetCalculatedAmountResultDTO(calculatedAmount));
     }
 

--- a/src/main/java/umc/haruchi/web/dto/MonthBudgetResponseDTO.java
+++ b/src/main/java/umc/haruchi/web/dto/MonthBudgetResponseDTO.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import umc.haruchi.domain.DayBudget;
+import umc.haruchi.domain.enums.ClosingStatus;
 import umc.haruchi.domain.enums.DayBudgetStatus;
 
 import java.time.LocalDate;
@@ -56,6 +57,7 @@ public class MonthBudgetResponseDTO {
         Long day;
         Integer dayBudget;
         DayBudgetStatus status;
+        ClosingStatus closingState;
     }
 
     @Builder


### PR DESCRIPTION
## 💡 관련 이슈

#44  #40  

## 📢 작업 내용

- 지출 마감에서 1/n경우의 하루 차감/분배 값 조회 API amount 받는거에서  dayBudget.getDayBudget 사용하는 것으로 변경
- 한 주 예산 조회 리스트에 closingState추가(member에 enum 추가하여 지출 마감 때 업데이트 되도록 구현했습니다. -> (enum 값) ZERO, PLUS, MINUS, ETC -> ETC를 DEFAULT로 두고, 현재 1일일 경우 INACTIVE이면서 ETC인것들을 필요한 경우에 프론트에서 거르면 될 듯 합니다 ! -> 지출 영수증 조회는 사실 상관없이 잘 되기 때문에 꼭 거르지 않아도 될 것 같습니다!)

## 🗨️ 리뷰 요구사항(선택)
지금 잘 돌아가서 리팩토링 당장은 안해도 될 것 같은데 하게 된다면 ETC는 삭제하면 될 것 같습니다!


## ✅ 체크리스트

- [x]  코드가 정상적으로 컴파일되나요?
- [x]  이슈 내용을 전부 구현했나요?
- [x]  작업 기간 내에 개발을 완료했나요?
- [x]  리뷰어를 선택했나요?
- [x]  라벨을 지정했나요?
