### PR TITLE
[REFACTOR] 리프레시 토큰 삭제 및 액세스 토큰 만료 시간 삭제

### DIFF
--- a/src/main/java/umc/haruchi/config/login/SecurityConfig.java
+++ b/src/main/java/umc/haruchi/config/login/SecurityConfig.java
@@ -85,7 +85,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests((request) -> request
                         .requestMatchers("/member/signup/**").permitAll()
                         .requestMatchers("/member/login").permitAll()
-                        .requestMatchers("/member/refresh").permitAll()
+//                        .requestMatchers("/member/refresh").permitAll() // 보안 강화 시 주석 처리 해제
                         .requestMatchers("/health").permitAll()  // health check
                         .requestMatchers(AUTH_WHITELIST).permitAll()
                         .anyRequest().authenticated())

--- a/src/main/java/umc/haruchi/config/login/jwt/JwtUtil.java
+++ b/src/main/java/umc/haruchi/config/login/jwt/JwtUtil.java
@@ -128,6 +128,19 @@ public class JwtUtil implements InitializingBean {
         return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
     }
 
+    public static String createNewAccessJwt(Long memberId, String email, String role) {
+        return Jwts.builder()
+                .header()
+                .add("typ", "JWT")
+                .and()
+                .claim("memberId", memberId)
+                .claim("email", email)
+                .claim("role", role)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .signWith(secretKey)
+                .compact();
+    }
+
     public static String createRefreshJwt(Long memberId, String email, String role) {
         return Jwts.builder()
                 .header()

--- a/src/main/java/umc/haruchi/config/login/jwt/JwtUtil.java
+++ b/src/main/java/umc/haruchi/config/login/jwt/JwtUtil.java
@@ -141,33 +141,34 @@ public class JwtUtil implements InitializingBean {
                 .compact();
     }
 
-    public static String createRefreshJwt(Long memberId, String email, String role) {
-        return Jwts.builder()
-                .header()
-                .add("typ", "JWT")
-                .and()
-                .claim("memberId", memberId)
-                .claim("email", email)
-                .claim("role", role)
-                .issuedAt(new Date(System.currentTimeMillis()))
-                .expiration(new Date(System.currentTimeMillis() + refreshExpireMs))
-                .signWith(secretKey)
-                .compact();
-    }
-
-    public static String createAccessJwt(Long memberId, String email, String role) {
-        return Jwts.builder()
-                .header()
-                .add("typ", "JWT")
-                .and()
-                .claim("memberId", memberId)
-                .claim("email", email)
-                .claim("role", role)
-                .issuedAt(new Date(System.currentTimeMillis()))
-                .expiration(new Date(System.currentTimeMillis() + accessExpireMs))
-                .signWith(secretKey)
-                .compact();
-    }
+    // 기존 토큰 발급 기능 - 보안 강화 시 주석 처리 해제
+//    public static String createRefreshJwt(Long memberId, String email, String role) {
+//        return Jwts.builder()
+//                .header()
+//                .add("typ", "JWT")
+//                .and()
+//                .claim("memberId", memberId)
+//                .claim("email", email)
+//                .claim("role", role)
+//                .issuedAt(new Date(System.currentTimeMillis()))
+//                .expiration(new Date(System.currentTimeMillis() + refreshExpireMs))
+//                .signWith(secretKey)
+//                .compact();
+//    }
+//
+//    public static String createAccessJwt(Long memberId, String email, String role) {
+//        return Jwts.builder()
+//                .header()
+//                .add("typ", "JWT")
+//                .and()
+//                .claim("memberId", memberId)
+//                .claim("email", email)
+//                .claim("role", role)
+//                .issuedAt(new Date(System.currentTimeMillis()))
+//                .expiration(new Date(System.currentTimeMillis() + accessExpireMs))
+//                .signWith(secretKey)
+//                .compact();
+//    }
 
     public static String getPassword(String token) {
         return Jwts.parser()

--- a/src/main/java/umc/haruchi/service/MemberService.java
+++ b/src/main/java/umc/haruchi/service/MemberService.java
@@ -262,18 +262,18 @@ public class MemberService {
 //    }
 
     // 새 회원 탈퇴 - 이유 저장 + 회원 정보 영구 삭제
-    public void newWithdrawer(String reason, Member member) {
+    public void newWithdrawer(String reason, String accessToken) {
         Withdrawer withdrawer = Withdrawer.builder()
                 .reason(reason)
                 .build();
         withdrawerRepository.save(withdrawer);
 
-        if (memberRepository.findByEmail(member.getEmail()).isPresent()) {
-            memberRepository.delete(member);
-        }
-        else {
-            throw new MemberHandler(ErrorStatus.NO_MEMBER_EXIST);
-        }
+        String email = jwtUtil.getEmail(accessToken);
+
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.NO_MEMBER_EXIST));
+
+        memberRepository.delete(member);
     }
 
     // 기존 회원 탈퇴 - 이유 저장 (보안 강화 시 주석 처리 해제)

--- a/src/main/java/umc/haruchi/service/MemberService.java
+++ b/src/main/java/umc/haruchi/service/MemberService.java
@@ -1,9 +1,11 @@
 package umc.haruchi.service;
 
+import io.jsonwebtoken.JwtException;
 import jakarta.mail.Message;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
+import lombok.With;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -223,38 +225,64 @@ public class MemberService {
 //                .build();
 //    }
 
-    // 로그아웃 (액세스 토큰 블랙리스트에 저장)
-    public void logout(String accessToken, String refreshToken, String type) {
-
+    // 새 로그아웃; 토큰 블랙리스트화(만료 시간 X) + refresh token 삭제 X
+    public void newLogout(String accessToken) {
         try {
             jwtUtil.validateToken(accessToken);
-        } catch (JwtExceptionHandler e) {
+        } catch (JwtException e) {
             throw new JwtExceptionHandler(ErrorStatus.NOT_VALID_TOKEN.getMessage());
         }
 
-        String email = jwtUtil.getEmail(accessToken);
-
-        if (redisTemplate.opsForValue().get("RT" + email) != null) {
-            redisTemplate.delete("RT" + email);
-        }
-
-        Long expiration = JwtUtil.getExpiration(accessToken);
-        redisTemplate.opsForValue().set(accessToken, "logout", expiration, TimeUnit.MILLISECONDS);
-
-        if (type.equals("DELETE")) {
-            Member member = memberRepository.findByEmail(email)
-                    .orElseThrow(() -> new MemberHandler(ErrorStatus.NO_MEMBER_EXIST));
-            memberRepository.delete(member);
-        }
+        redisTemplate.opsForValue().set(accessToken, "logout");
     }
 
-    // 회원 즉시 탈퇴 - 이유 저장
-    public void withdrawer(String reason) {
+    // 기존 로그아웃 - 액세스 토큰 블랙리스트에 저장 (보안 강화 시 주석 처리 해제)
+//    public void logout(String accessToken, String refreshToken, String type) {
+//
+//        try {
+//            jwtUtil.validateToken(accessToken);
+//        } catch (JwtExceptionHandler e) {
+//            throw new JwtExceptionHandler(ErrorStatus.NOT_VALID_TOKEN.getMessage());
+//        }
+//
+//        String email = jwtUtil.getEmail(accessToken);
+//
+//        if (redisTemplate.opsForValue().get("RT" + email) != null) {
+//            redisTemplate.delete("RT" + email);
+//        }
+//
+//        Long expiration = JwtUtil.getExpiration(accessToken);
+//        redisTemplate.opsForValue().set(accessToken, "logout", expiration, TimeUnit.MILLISECONDS);
+//
+//        if (type.equals("DELETE")) {
+//            Member member = memberRepository.findByEmail(email)
+//                    .orElseThrow(() -> new MemberHandler(ErrorStatus.NO_MEMBER_EXIST));
+//            memberRepository.delete(member);
+//        }
+//    }
+
+    // 새 회원 탈퇴 - 이유 저장 + 회원 정보 영구 삭제
+    public void newWithdrawer(String reason, Member member) {
         Withdrawer withdrawer = Withdrawer.builder()
                 .reason(reason)
                 .build();
         withdrawerRepository.save(withdrawer);
+
+        if (memberRepository.findByEmail(member.getEmail()).isPresent()) {
+            memberRepository.delete(member);
+        }
+        else {
+            throw new MemberHandler(ErrorStatus.NO_MEMBER_EXIST);
+        }
     }
+
+    // 기존 회원 탈퇴 - 이유 저장 (보안 강화 시 주석 처리 해제)
+//    public void withdrawer(String reason) {
+//        Withdrawer withdrawer = Withdrawer.builder()
+//                .reason(reason)
+//                .build();
+//        withdrawerRepository.save(withdrawer);
+//    }
 
 
     // 회원 더보기 정보(가입일, 가입 이메일, 닉네임) 조회

--- a/src/main/java/umc/haruchi/service/MemberService.java
+++ b/src/main/java/umc/haruchi/service/MemberService.java
@@ -170,39 +170,39 @@ public class MemberService {
                 .build();
     }
 
-    // 토큰 재발급
-    public MemberResponseDTO.LoginJwtTokenDTO reissue(String refreshToken) {
-
-        if (!jwtUtil.validateToken(refreshToken)) {
-            throw new JwtExceptionHandler(ErrorStatus.NOT_VALID_TOKEN.getMessage());
-        }
-
-        String email = jwtUtil.getEmail(refreshToken);
-
-        Object o = redisTemplate.opsForValue().get("RT" + email);
-        if (o == null) {
-            throw new JwtExceptionHandler(ErrorStatus.NO_MATCH_REFRESHTOKEN.getMessage());
-        }
-
-        Member member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new MemberHandler(ErrorStatus.NO_MEMBER_EXIST));
-
-        String newAccessToken = JwtUtil.createAccessJwt(member.getId(), member.getEmail(), null);
-        String newRefreshToken = JwtUtil.createRefreshJwt(member.getId(), member.getEmail(), null);
-
-        Long accessExpiredAt = JwtUtil.getExpiration(newAccessToken);
-        Long refreshExpiredAt = JwtUtil.getExpiration(newRefreshToken);
-
-        redisTemplate.opsForValue().set("RT" + member.getEmail(), newRefreshToken, refreshExpiredAt, TimeUnit.MILLISECONDS);
-
-        return MemberResponseDTO.LoginJwtTokenDTO.builder()
-                .grantType("Bearer")
-                .accessToken(newAccessToken)
-                .accessTokenExpiresAt(accessExpiredAt)
-                .refreshToken(newRefreshToken)
-                .refreshTokenExpirationAt(refreshExpiredAt)
-                .build();
-    }
+    // 토큰 재발급 (보안 강화 시 주석 처리 해제)
+//    public MemberResponseDTO.LoginJwtTokenDTO reissue(String refreshToken) {
+//
+//        if (!jwtUtil.validateToken(refreshToken)) {
+//            throw new JwtExceptionHandler(ErrorStatus.NOT_VALID_TOKEN.getMessage());
+//        }
+//
+//        String email = jwtUtil.getEmail(refreshToken);
+//
+//        Object o = redisTemplate.opsForValue().get("RT" + email);
+//        if (o == null) {
+//            throw new JwtExceptionHandler(ErrorStatus.NO_MATCH_REFRESHTOKEN.getMessage());
+//        }
+//
+//        Member member = memberRepository.findByEmail(email)
+//                .orElseThrow(() -> new MemberHandler(ErrorStatus.NO_MEMBER_EXIST));
+//
+//        String newAccessToken = JwtUtil.createAccessJwt(member.getId(), member.getEmail(), null);
+//        String newRefreshToken = JwtUtil.createRefreshJwt(member.getId(), member.getEmail(), null);
+//
+//        Long accessExpiredAt = JwtUtil.getExpiration(newAccessToken);
+//        Long refreshExpiredAt = JwtUtil.getExpiration(newRefreshToken);
+//
+//        redisTemplate.opsForValue().set("RT" + member.getEmail(), newRefreshToken, refreshExpiredAt, TimeUnit.MILLISECONDS);
+//
+//        return MemberResponseDTO.LoginJwtTokenDTO.builder()
+//                .grantType("Bearer")
+//                .accessToken(newAccessToken)
+//                .accessTokenExpiresAt(accessExpiredAt)
+//                .refreshToken(newRefreshToken)
+//                .refreshTokenExpirationAt(refreshExpiredAt)
+//                .build();
+//    }
 
     // 로그아웃 (액세스 토큰 블랙리스트에 저장)
     public void logout(String accessToken, String refreshToken, String type) {

--- a/src/main/java/umc/haruchi/web/controller/MemberApiController.java
+++ b/src/main/java/umc/haruchi/web/controller/MemberApiController.java
@@ -126,10 +126,9 @@ public class MemberApiController {
     @PostMapping("/delete")
     @Operation(summary = "회원탈퇴 API", description = "회원탈퇴를 진행하는 API (토큰 만료 및 회원 영구 삭제)")
     public ApiResponse<MemberResponseDTO> deleteMember(@RequestHeader("Authorization") String accessToken,
-                                                       @RequestParam String reason,
-                                                       @AuthenticationPrincipal Member member) {
+                                                       @RequestParam String reason) {
+        memberService.newWithdrawer(reason,accessToken.substring(7));
         memberService.newLogout(accessToken.substring(7));
-        memberService.newWithdrawer(reason,member);
         return ApiResponse.onSuccess(null);
     }
 

--- a/src/main/java/umc/haruchi/web/controller/MemberApiController.java
+++ b/src/main/java/umc/haruchi/web/controller/MemberApiController.java
@@ -84,15 +84,15 @@ public class MemberApiController {
         return "login user";
     }
 
-    @PostMapping("/refresh") // 오류 발생 -> 헤더 인식 불가능
-    @Operation(summary = "액세스 토큰과 리프레시 토큰 재발급 API", description = "리프레시 토큰으로 액세스 토큰과 리프레시 토큰을 재발급하는 API  (액세스 토큰 필요 없음)")
-    @Parameters({
-            @Parameter(name = "refreshToken", description = "리프레시 토큰")
-    })
-    public ApiResponse<MemberResponseDTO.LoginJwtTokenDTO> refreshToken(@RequestParam("refreshToken") String refreshToken) {
-        MemberResponseDTO.LoginJwtTokenDTO tokens = memberService.reissue(refreshToken);
-        return ApiResponse.onSuccess(tokens);
-    }
+//    @PostMapping("/refresh") // 보안 강화 시 주석 처리 해제
+//    @Operation(summary = "액세스 토큰과 리프레시 토큰 재발급 API", description = "리프레시 토큰으로 액세스 토큰과 리프레시 토큰을 재발급하는 API  (액세스 토큰 필요 없음)")
+//    @Parameters({
+//            @Parameter(name = "refreshToken", description = "리프레시 토큰")
+//    })
+//    public ApiResponse<MemberResponseDTO.LoginJwtTokenDTO> refreshToken(@RequestParam("refreshToken") String refreshToken) {
+//        MemberResponseDTO.LoginJwtTokenDTO tokens = memberService.reissue(refreshToken);
+//        return ApiResponse.onSuccess(tokens);
+//    }
 
     @PostMapping("/logout")
     @Operation(summary = "로그아웃 API", description = "로그아웃을 진행하는 API (토큰 만료 및 블랙리스트화)")

--- a/src/main/java/umc/haruchi/web/controller/MemberApiController.java
+++ b/src/main/java/umc/haruchi/web/controller/MemberApiController.java
@@ -72,7 +72,8 @@ public class MemberApiController {
         return ApiResponse.onSuccess(null);
     }
 
-//    @PostMapping("/login") // 보안 강화 시 주석 처리 해제
+    // 보안 강화 시 주석 처리 해제
+//    @PostMapping("/login")
 //    @Operation(summary = "로그인 API", description = "로그인을 진행하는 API (토큰 발급) (액세스 토큰 필요 없음)")
 //    public ApiResponse<MemberResponseDTO.LoginJwtTokenDTO> login(@Valid @RequestBody MemberRequestDTO.MemberLoginDTO request) {
 //        MemberResponseDTO.LoginJwtTokenDTO token = memberService.login(request);
@@ -91,7 +92,8 @@ public class MemberApiController {
         return "login user";
     }
 
-//    @PostMapping("/refresh") // 보안 강화 시 주석 처리 해제
+    // 보안 강화 시 주석 처리 해제
+//    @PostMapping("/refresh")
 //    @Operation(summary = "액세스 토큰과 리프레시 토큰 재발급 API", description = "리프레시 토큰으로 액세스 토큰과 리프레시 토큰을 재발급하는 API  (액세스 토큰 필요 없음)")
 //    @Parameters({
 //            @Parameter(name = "refreshToken", description = "리프레시 토큰")
@@ -103,23 +105,42 @@ public class MemberApiController {
 
     @PostMapping("/logout")
     @Operation(summary = "로그아웃 API", description = "로그아웃을 진행하는 API (토큰 만료 및 블랙리스트화)")
-    @Parameters({
-            @Parameter(name = "accessToken", description = "액세스 토큰"),
-            @Parameter(name = "refreshToken", description = "리프레시 토큰")
-    })
-    public ApiResponse<MemberResponseDTO> logout(@RequestParam("accessToken") String accessToken,
-                                                 @RequestParam("refreshToken") String refreshToken) {
-        memberService.logout(accessToken, refreshToken, "LOGOUT");
+    public ApiResponse<MemberResponseDTO> logout(@RequestHeader("Authorization") String accessToken) {
+        memberService.newLogout(accessToken.substring(7));
         return ApiResponse.onSuccess(null);
     }
 
+    // 보안 강화 시 주석 처리 해제
+//    @PostMapping("/logout")
+//    @Operation(summary = "로그아웃 API", description = "로그아웃을 진행하는 API (토큰 만료 및 블랙리스트화)")
+//    @Parameters({
+//            @Parameter(name = "accessToken", description = "액세스 토큰"),
+//            @Parameter(name = "refreshToken", description = "리프레시 토큰")
+//    })
+//    public ApiResponse<MemberResponseDTO> logout(@RequestParam("accessToken") String accessToken,
+//                                                 @RequestParam("refreshToken") String refreshToken) {
+//        memberService.logout(accessToken, refreshToken, "LOGOUT");
+//        return ApiResponse.onSuccess(null);
+//    }
+
     @PostMapping("/delete")
     @Operation(summary = "회원탈퇴 API", description = "회원탈퇴를 진행하는 API (토큰 만료 및 회원 영구 삭제)")
-    public ApiResponse<MemberResponseDTO> deleteMember(@Valid @RequestBody MemberRequestDTO.MemberWithdrawRequestDTO request) {
-        memberService.logout(request.getAccessToken(), request.getRefreshToken(), "DELETE");
-        memberService.withdrawer(request.getReason());
+    public ApiResponse<MemberResponseDTO> deleteMember(@RequestHeader("Authorization") String accessToken,
+                                                       @RequestParam String reason,
+                                                       @AuthenticationPrincipal Member member) {
+        memberService.newLogout(accessToken.substring(7));
+        memberService.newWithdrawer(reason,member);
         return ApiResponse.onSuccess(null);
     }
+
+    // 보안 강화 시 주석 처리 해제
+//    @PostMapping("/delete")
+//    @Operation(summary = "회원탈퇴 API", description = "회원탈퇴를 진행하는 API (토큰 만료 및 회원 영구 삭제)")
+//    public ApiResponse<MemberResponseDTO> deleteMember(@Valid @RequestBody MemberRequestDTO.MemberWithdrawRequestDTO request) {
+//        memberService.logout(request.getAccessToken(), request.getRefreshToken(), "DELETE");
+//        memberService.withdrawer(request.getReason());
+//        return ApiResponse.onSuccess(null);
+//    }
 
     @GetMapping("/")
     @Operation(summary = "회원정보조회 API", description = "헤더에 있는 토큰으로 회원을 식별하고, 더보기 화면에서 회원의 정보를 조회하는 API")

--- a/src/main/java/umc/haruchi/web/controller/MemberApiController.java
+++ b/src/main/java/umc/haruchi/web/controller/MemberApiController.java
@@ -72,10 +72,17 @@ public class MemberApiController {
         return ApiResponse.onSuccess(null);
     }
 
+//    @PostMapping("/login") // 보안 강화 시 주석 처리 해제
+//    @Operation(summary = "로그인 API", description = "로그인을 진행하는 API (토큰 발급) (액세스 토큰 필요 없음)")
+//    public ApiResponse<MemberResponseDTO.LoginJwtTokenDTO> login(@Valid @RequestBody MemberRequestDTO.MemberLoginDTO request) {
+//        MemberResponseDTO.LoginJwtTokenDTO token = memberService.login(request);
+//        return ApiResponse.onSuccess(token);
+//    }
+
     @PostMapping("/login")
-    @Operation(summary = "로그인 API", description = "로그인을 진행하는 API (토큰 발급) (액세스 토큰 필요 없음)")
-    public ApiResponse<MemberResponseDTO.LoginJwtTokenDTO> login(@Valid @RequestBody MemberRequestDTO.MemberLoginDTO request) {
-        MemberResponseDTO.LoginJwtTokenDTO token = memberService.login(request);
+    @Operation(summary = "로그인 API", description = "로그인을 진행하는 API (토큰 방급; 액세스 토큰 필요 없음)")
+    public ApiResponse<MemberResponseDTO.NewLoginJwtTokenDTO> login(@Valid @RequestBody MemberRequestDTO.MemberLoginDTO request) {
+        MemberResponseDTO.NewLoginJwtTokenDTO token = memberService.newLogin(request);
         return ApiResponse.onSuccess(token);
     }
 

--- a/src/main/java/umc/haruchi/web/dto/MemberResponseDTO.java
+++ b/src/main/java/umc/haruchi/web/dto/MemberResponseDTO.java
@@ -19,16 +19,27 @@ public class MemberResponseDTO {
         LocalDateTime createdAt;
     }
 
+    // 기존 로그인 방식(access token과 refresh token 발급; 각각 만료 시간 존재)
+//    @Builder
+//    @Getter
+//    @NoArgsConstructor
+//    @AllArgsConstructor
+//    public static class LoginJwtTokenDTO {
+//        String grantType;
+//        String accessToken;
+//        Long accessTokenExpiresAt;
+//        String refreshToken;
+//        Long refreshTokenExpirationAt;
+//    }
+
+    // 새 로그인 방식(access token 발급; 만료 시간 없음)
     @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class LoginJwtTokenDTO {
+    public static class NewLoginJwtTokenDTO {
         String grantType;
         String accessToken;
-        Long accessTokenExpiresAt;
-        String refreshToken;
-        Long refreshTokenExpirationAt;
     }
 
     @Builder


### PR DESCRIPTION
## 💡 관련 이슈

#53 

## 📢 작업 내용

- 리프레시 토큰 관련 기능 삭제(토큰 발급 및 재발급, redis 저장 등)
- 로그아웃 및 회원탈퇴 기능 수정

## 🗨️ 리뷰 요구사항(선택)

- ~회원가입하면 ACTIVE한 하루예산에 ClosingStatus가 ETC로 설정되는 오류 수정 필요~
  - DB 테이블 다 drop하고 create하니까 정상 작동
- 로그아웃한 액세스 토큰이 redis에 영구 저장되는 문제
  - 기존 로그인 방식으로 바꾸면 문제 없음 (런칭 시 바꾸기)

## ✅ 체크리스트

- [x]  코드가 정상적으로 컴파일되나요?
- [x]  이슈 내용을 전부 구현했나요?
- [x]  작업 기간 내에 개발을 완료했나요?
- [x]  리뷰어를 선택했나요?
- [x]  라벨을 지정했나요?
