### PR TITLE
[FIX] 당겨쓰기 EVENLY옵션 로직 수정

### DIFF
--- a/src/main/java/umc/haruchi/service/BudgetRedistributionService.java
+++ b/src/main/java/umc/haruchi/service/BudgetRedistributionService.java
@@ -207,8 +207,7 @@ public class BudgetRedistributionService {
         long dayCount = monthBudget.getDayBudgetList().stream()
                 .filter(dayBudget -> dayBudget.getDay() >= localNowDay).count() - 1;
 
-        //고르게 당겨쓰기(233원씩 당겨온다고하면 200 * 일수 당겨와서 target에 저장, 233원씩 차감, 67원씩 세이프박스로))
-        //0813 수정 : 233 * 일수 당겨와서 target에 저장, 233원씩 차감, 67원씩 세이프박스, source 절사 후 세이프박스
+        //0813 수정 : 233 * 일수 당겨와서 target에 저장, 233원씩 차감, 67원씩 세이프박스, target 절사 후 세이프박스
         if (request.getRedistributionOption().equals(EVENLY)) {
 
             //dayCount가 0일때 -> 마지막 날일 때 예외처리


### PR DESCRIPTION
## 💡 관련 이슈

#25 

## 📢 작업 내용

- 고르게 당겨쓰기 로직 수정 
233원씩 당겨온다고하면 200 * 일수 당겨와서 target에 저장, 233원씩 차감, 67원씩 세이프박스로 -> 
        233 * 일수 당겨와서 target에 저장, 233원씩 차감, 67원씩 세이프박스, target 절사 후 세이프박스

## 🗨️ 리뷰 요구사항(선택)

x
## ✅ 체크리스트

- [x]  코드가 정상적으로 컴파일되나요?
- [ ]  이슈 내용을 전부 구현했나요?
- [ ]  작업 기간 내에 개발을 완료했나요?
- [x]  리뷰어를 선택했나요?
- [x]  라벨을 지정했나요?
